### PR TITLE
Add `Send` and `Sync` to `PrimeField::Config` trait constraints

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -52,7 +52,7 @@ pub trait PrimeField: Field {
     /// Runtime configuration for the prime field, empty for constant prime
     /// fields. For dynamic prime fields, it could be just modulus or more
     /// complex structure.
-    type Config: Debug + Clone + 'static;
+    type Config: Debug + Clone + Send + Sync + 'static;
 
     fn cfg(&self) -> &Self::Config;
 


### PR DESCRIPTION
`Send` and `Sync` are already implemented for the config type we've had so far so there's no harm in adding those.

Going forward it doesn't seem unreasonable to me to require those from prime field config types.