### PR TITLE
Add mutable access to inner in `Field` trait

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -39,6 +39,7 @@ pub trait Field:
     type Inner: Debug + Eq + Clone;
 
     fn inner(&self) -> &Self::Inner;
+    fn inner_mut(&mut self) -> &mut Self::Inner;
 }
 
 /// Element of an integer field modulo prime number (F_p).

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -401,8 +401,14 @@ impl<F: ArkWrappedField> Ring for ArkField<F> {}
 impl<F: ArkWrappedField> Field for ArkField<F> {
     type Inner = F;
 
+    #[inline(always)]
     fn inner(&self) -> &Self::Inner {
         &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
     }
 }
 

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -472,8 +472,14 @@ impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
 impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     type Inner = BigInt<N>;
 
+    #[inline(always)]
     fn inner(&self) -> &Self::Inner {
         &self.0.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0.0
     }
 }
 

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -425,6 +425,17 @@ impl Field for BoxedMontyField {
     fn inner(&self) -> &Self::Inner {
         self.0.as_montgomery()
     }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        // TODO: address this once possible.
+        unimplemented!(
+            "For now we keep this unimplemented. \
+            The method was introduced in crypto-bigint in this PR:\
+            https://github.com/RustCrypto/crypto-bigint/pull/1014\
+            but not yet available in the latest RC from the craits.io."
+        )
+    }
 }
 
 impl PrimeField for BoxedMontyField {

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -516,6 +516,11 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMB
     fn inner(&self) -> &Self::Inner {
         Uint::new_ref(self.0.as_montgomery())
     }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        Uint::new_ref_mut(self.0.as_montgomery_mut())
+    }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstPrimeField for ConstMontyField<Mod, LIMBS> {

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -486,6 +486,11 @@ impl<const LIMBS: usize> Field for MontyField<LIMBS> {
     fn inner(&self) -> &Self::Inner {
         Uint::new_ref(self.0.as_montgomery())
     }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        Uint::new_ref_mut(self.0.as_montgomery_mut())
+    }
 }
 
 impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {


### PR DESCRIPTION
Add 
```rust 
fn inner_mut(&mut self) -> &mut Self::Inner;
```
to the `Field` trait and implement it for the existing implementations of the trait.

Note: there's no means to do it for the `BoxedMontyField` now so left it unimplemented.