### PR TITLE
Improved Boolean type conversion

### DIFF
--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{crypto_bigint_uint::Uint, impl_pow_via_repeated_squaring};
+use crate::{boolean::Boolean, crypto_bigint_uint::Uint, impl_pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -457,6 +457,13 @@ impl<const LIMBS: usize> From<bool> for Int<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> From<Boolean> for Int<LIMBS> {
+    #[inline(always)]
+    fn from(value: Boolean) -> Self {
+        Self::from(value.into_inner())
+    }
+}
+
 macro_rules! impl_from_signed_primitive {
     ($($t:ty),+) => {
         $(
@@ -789,6 +796,9 @@ mod tests {
         let wrapped = Int4::new(value);
         assert_eq!(wrapped.inner(), &value);
         assert_eq!(wrapped.into_inner(), value);
+
+        assert_eq!(Int4::from(true), Int4::ONE);
+        assert_eq!(Int4::from(Boolean::TRUE), Int4::ONE);
     }
 
     #[test]

--- a/src/semiring/boolean.rs
+++ b/src/semiring/boolean.rs
@@ -147,12 +147,20 @@ impl From<bool> for Boolean {
     }
 }
 
-impl From<Boolean> for bool {
-    #[inline(always)]
-    fn from(value: Boolean) -> Self {
-        value.0
-    }
+macro_rules! impl_from_boolean_for {
+    ($($to:ty),*) => {$(
+        impl From<Boolean> for $to {
+            #[inline(always)]
+            fn from(value: Boolean) -> Self {
+                value.0 as $to
+            }
+        }
+    )*};
 }
+
+impl_from_boolean_for!(bool);
+impl_from_boolean_for!(i8, i16, i32, i64, i128, isize);
+impl_from_boolean_for!(u8, u16, u32, u64, u128, usize);
 
 //
 // Basic arithmetic operations
@@ -533,6 +541,15 @@ mod tests {
         assert_eq!(Boolean::from_u8(0), Boolean::FALSE);
         assert_eq!(Boolean::from_u8(1), Boolean::TRUE);
         assert_eq!(Boolean::from_u8(2), Boolean::TRUE);
+    }
+
+    #[test]
+    fn reverse_conversions() {
+        assert_eq!(bool::from(Boolean::TRUE), true);
+        assert_eq!(i8::from(Boolean::TRUE), 1);
+        assert_eq!(i128::from(Boolean::TRUE), 1);
+        assert_eq!(u8::from(Boolean::TRUE), 1);
+        assert_eq!(u128::from(Boolean::TRUE), 1);
     }
 
     #[test]

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{crypto_bigint_int::Int, impl_pow_via_repeated_squaring};
+use crate::{boolean::Boolean, crypto_bigint_int::Int, impl_pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -486,6 +486,13 @@ impl<const LIMBS: usize> From<bool> for Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> From<Boolean> for Uint<LIMBS> {
+    #[inline(always)]
+    fn from(value: Boolean) -> Self {
+        Self::from(value.into_inner())
+    }
+}
+
 macro_rules! impl_from_primitive {
     ($($t:ty),+) => {
         $(
@@ -746,6 +753,9 @@ mod tests {
         let wrapped = Uint4::new(value);
         assert_eq!(wrapped.inner(), &value);
         assert_eq!(wrapped.into_inner(), value);
+
+        assert_eq!(Uint4::from(true), Uint4::ONE);
+        assert_eq!(Uint4::from(Boolean::TRUE), Uint4::ONE);
     }
 
     #[test]


### PR DESCRIPTION
Added several forgotten `From<Boolean>` implementations - for primitives, `Int<_>` and `Uint<_>`.
Prime fields already had those.