### PR TITLE
Inline always in `_monty` fields

### DIFF
--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -32,12 +32,14 @@ impl BoxedMontyField {
 //
 
 impl Debug for BoxedMontyField {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Debug::fmt(&self.0, f)
     }
 }
 
 impl Display for BoxedMontyField {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(
             f,
@@ -49,6 +51,7 @@ impl Display for BoxedMontyField {
 }
 
 impl PartialOrd for BoxedMontyField {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.modulus() != other.modulus() {
             return None;
@@ -58,6 +61,7 @@ impl PartialOrd for BoxedMontyField {
 }
 
 impl Hash for BoxedMontyField {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.as_montgomery().hash(state)
     }
@@ -70,6 +74,7 @@ impl Hash for BoxedMontyField {
 impl Neg for BoxedMontyField {
     type Output = Self;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         Self(self.0.neg())
     }
@@ -122,6 +127,7 @@ impl_basic_op!(Mul, mul);
 impl Div for BoxedMontyField {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: Self) -> Self::Output {
         self.div(&rhs)
     }
@@ -130,6 +136,7 @@ impl Div for BoxedMontyField {
 impl Div<&Self> for BoxedMontyField {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: &Self) -> Self::Output {
         self.checked_div(rhs).expect("Division by zero")
     }
@@ -138,6 +145,7 @@ impl Div<&Self> for BoxedMontyField {
 impl Div for &BoxedMontyField {
     type Output = BoxedMontyField;
 
+    #[inline(always)]
     fn div(self, rhs: Self) -> Self::Output {
         self.checked_div(rhs).expect("Division by zero")
     }
@@ -146,6 +154,7 @@ impl Div for &BoxedMontyField {
 impl Div<BoxedMontyField> for &BoxedMontyField {
     type Output = BoxedMontyField;
 
+    #[inline(always)]
     fn div(self, rhs: BoxedMontyField) -> Self::Output {
         self.div(&rhs)
     }
@@ -154,6 +163,7 @@ impl Div<BoxedMontyField> for &BoxedMontyField {
 impl Pow<u32> for BoxedMontyField {
     type Output = Self;
 
+    #[inline(always)]
     fn pow(self, rhs: u32) -> Self::Output {
         Self(self.0.pow(&BoxedUint::from(rhs)))
     }
@@ -162,6 +172,7 @@ impl Pow<u32> for BoxedMontyField {
 impl Inv for BoxedMontyField {
     type Output = Option<Self>;
 
+    #[inline(always)]
     fn inv(self) -> Self::Output {
         Some(Self(Option::from(self.0.invert_vartime())?))
     }
@@ -170,6 +181,7 @@ impl Inv for BoxedMontyField {
 impl Inv for &BoxedMontyField {
     type Output = Option<BoxedMontyField>;
 
+    #[inline(always)]
     fn inv(self) -> Self::Output {
         Some(BoxedMontyField(Option::from(self.0.invert_vartime())?))
     }
@@ -182,6 +194,7 @@ impl Inv for &BoxedMontyField {
 
 impl CheckedDiv for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn checked_div(&self, rhs: &Self) -> Option<Self> {
         Some(self * rhs.inv()?)
     }
@@ -194,11 +207,13 @@ impl CheckedDiv for BoxedMontyField {
 macro_rules! impl_field_op_assign {
     ($trait:ident, $method:ident) => {
         impl $trait for BoxedMontyField {
+            #[inline(always)]
             fn $method(&mut self, rhs: Self) {
                 self.0.$method(&rhs.0);
             }
         }
         impl $trait<&Self> for BoxedMontyField {
+            #[inline(always)]
             fn $method(&mut self, rhs: &Self) {
                 self.0.$method(&rhs.0);
             }
@@ -211,12 +226,14 @@ impl_field_op_assign!(SubAssign, sub_assign);
 impl_field_op_assign!(MulAssign, mul_assign);
 
 impl DivAssign for BoxedMontyField {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: Self) {
         self.div_assign(&rhs);
     }
 }
 
 impl DivAssign<&Self> for BoxedMontyField {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: &Self) {
         self.0.mul_assign(rhs.0.invert().expect("Division by zero"))
     }
@@ -227,6 +244,7 @@ impl DivAssign<&Self> for BoxedMontyField {
 //
 
 impl Sum for BoxedMontyField {
+    #[inline(always)]
     fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(BoxedMontyField(first)) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for BoxedMontyField");
@@ -236,6 +254,7 @@ impl Sum for BoxedMontyField {
 }
 
 impl<'a> Sum<&'a Self> for BoxedMontyField {
+    #[inline(always)]
     fn sum<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(BoxedMontyField(first)) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for BoxedMontyField");
@@ -245,6 +264,7 @@ impl<'a> Sum<&'a Self> for BoxedMontyField {
 }
 
 impl Product for BoxedMontyField {
+    #[inline(always)]
     fn product<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(BoxedMontyField(first)) = iter.next() else {
             panic!("Product of an empty iterator is not defined for BoxedMontyField");
@@ -255,6 +275,7 @@ impl Product for BoxedMontyField {
 
 impl<'a> Product<&'a Self> for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn product<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(BoxedMontyField(first)) = iter.next() else {
             panic!("Product of an empty iterator is not defined for BoxedMontyField");
@@ -282,6 +303,7 @@ impl From<BoxedMontyField> for BoxedMontyForm {
 }
 
 impl From<&BoxedMontyField> for BoxedMontyField {
+    #[inline(always)]
     fn from(value: &Self) -> Self {
         value.clone()
     }
@@ -291,6 +313,7 @@ macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
             impl FromWithConfig<$t> for BoxedMontyField {
+                #[inline(always)]
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let abs: BoxedUint = value.into();
                     let abs = abs.resize(cfg.modulus().bits_precision());
@@ -299,6 +322,7 @@ macro_rules! impl_from_unsigned {
             }
 
             impl FromWithConfig<&$t> for BoxedMontyField {
+                #[inline(always)]
                 fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
                     Self::from_with_cfg(*value, cfg)
                 }
@@ -312,6 +336,7 @@ macro_rules! impl_from_signed {
         $(
             #[allow(clippy::arithmetic_side_effects)] // False alert
             impl FromWithConfig<$t> for BoxedMontyField {
+                #[inline(always)]
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let magnitude = BoxedUint::from(value.abs_diff(0)).resize(cfg.modulus().bits_precision());
                     let form = BoxedMontyForm::new(magnitude, cfg.clone());
@@ -320,6 +345,7 @@ macro_rules! impl_from_signed {
             }
 
             impl FromWithConfig<&$t> for BoxedMontyField {
+                #[inline(always)]
                 fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
                     Self::from_with_cfg(*value, cfg)
                 }
@@ -332,6 +358,7 @@ impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
 impl FromWithConfig<bool> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: bool, cfg: &Self::Config) -> Self {
         let magnitude: BoxedUint = if value {
             BoxedUint::one()
@@ -344,24 +371,28 @@ impl FromWithConfig<bool> for BoxedMontyField {
 }
 
 impl FromWithConfig<&bool> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: &bool, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }
 
 impl FromWithConfig<Boolean> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: Boolean, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }
 
 impl FromWithConfig<&Boolean> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: &Boolean, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }
 
 impl<const LIMBS: usize> FromWithConfig<Int<LIMBS>> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: Int<LIMBS>, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(&value, cfg)
     }
@@ -369,6 +400,7 @@ impl<const LIMBS: usize> FromWithConfig<Int<LIMBS>> for BoxedMontyField {
 
 impl<const LIMBS: usize> FromWithConfig<&Int<LIMBS>> for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn from_with_cfg(value: &Int<LIMBS>, cfg: &Self::Config) -> Self {
         let abs: BoxedUint = value.inner().abs().into();
         let abs = abs.resize(cfg.modulus().bits_precision());
@@ -380,12 +412,14 @@ impl<const LIMBS: usize> FromWithConfig<&Int<LIMBS>> for BoxedMontyField {
 }
 
 impl FromWithConfig<BoxedUint> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: BoxedUint, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(&value, cfg)
     }
 }
 
 impl FromWithConfig<&BoxedUint> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: &BoxedUint, cfg: &Self::Config) -> Self {
         let value = value.resize(cfg.modulus().bits_precision());
         Self(BoxedMontyForm::new(value, cfg.clone()))
@@ -393,6 +427,7 @@ impl FromWithConfig<&BoxedUint> for BoxedMontyField {
 }
 
 impl<const LIMBS: usize> FromWithConfig<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
+    #[inline(always)]
     fn from_with_cfg(value: crypto_bigint::Uint<LIMBS>, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(&value, cfg)
     }
@@ -400,6 +435,7 @@ impl<const LIMBS: usize> FromWithConfig<crypto_bigint::Uint<LIMBS>> for BoxedMon
 
 impl<const LIMBS: usize> FromWithConfig<&crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn from_with_cfg(value: &crypto_bigint::Uint<LIMBS>, cfg: &Self::Config) -> Self {
         let value: BoxedUint = value.into();
         let value = value.resize(cfg.modulus().bits_precision());
@@ -438,20 +474,24 @@ impl Field for BoxedMontyField {
 impl PrimeField for BoxedMontyField {
     type Config = BoxedMontyParams;
 
+    #[inline(always)]
     fn cfg(&self) -> &Self::Config {
         self.0.params()
     }
 
+    #[inline(always)]
     fn modulus(&self) -> Self::Inner {
         self.0.params().modulus().clone().get()
     }
 
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn modulus_minus_one_div_two(&self) -> Self::Inner {
         let value = self.0.params().modulus().clone().get();
         (value - BoxedUint::one()) / NonZero::new(BoxedUint::from(2_u8)).unwrap()
     }
 
+    #[inline(always)]
     fn make_cfg(modulus: &Self::Inner) -> Result<Self::Config, FieldError> {
         let Some(modulus) = Odd::new(modulus.clone()).into_option() else {
             return Err(FieldError::InvalidModulus);
@@ -459,22 +499,27 @@ impl PrimeField for BoxedMontyField {
         Ok(BoxedMontyParams::new(modulus))
     }
 
+    #[inline(always)]
     fn new_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
         Self(BoxedMontyForm::new(inner, cfg.clone()))
     }
 
+    #[inline(always)]
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
         Self(BoxedMontyForm::from_montgomery(inner, cfg.clone()))
     }
 
+    #[inline(always)]
     fn zero_with_cfg(cfg: &Self::Config) -> Self {
         Self(BoxedMontyForm::zero(cfg.clone()))
     }
 
+    #[inline(always)]
     fn is_zero_with_cfg(&self, _cfg: &Self::Config) -> bool {
         self.0.is_zero().into()
     }
 
+    #[inline(always)]
     fn one_with_cfg(cfg: &Self::Config) -> Self {
         Self(BoxedMontyForm::one(cfg.clone()))
     }

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -54,41 +54,49 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
 
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`],
     /// guaranteed to be reduced.
+    #[inline(always)]
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         Uint::new(self.0.retrieve())
     }
 
     /// Access the value in Montgomery form.
+    #[inline(always)]
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
         Uint::new_ref(self.0.as_montgomery())
     }
 
     /// Mutably access the value in Montgomery form.
+    #[inline(always)]
     pub fn as_montgomery_mut(&mut self) -> &mut Uint<LIMBS> {
         Uint::new_ref_mut(self.0.as_montgomery_mut())
     }
 
     /// Create a `ConstMontyForm` from a value in Montgomery form.
+    #[inline(always)]
     pub const fn from_montgomery(integer: Uint<LIMBS>) -> Self {
         Self(ConstMontyForm::from_montgomery(integer.into_inner()))
     }
 
     /// Extract the value from the `ConstMontyForm` in Montgomery form.
+    #[inline(always)]
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
         Uint::new(self.0.to_montgomery())
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[inline(always)]
     pub const fn div_by_2(&self) -> Self {
         Self(self.0.div_by_2())
     }
 
     /// Double `self`.
+    #[inline(always)]
     pub const fn double(&self) -> Self {
         Self(self.0.double())
     }
 
     /// See [ConstMontyForm::pow_bounded_exp].
+    #[inline(always)]
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
@@ -103,12 +111,14 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
 //
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Debug for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Debug::fmt(&self.0, f)
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Display for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{} (mod {})", self.0.retrieve(), Mod::PARAMS.modulus())
     }
@@ -122,18 +132,21 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Default for ConstMontyField<Mod, LI
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> PartialOrd for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Ord for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         Ord::cmp(self.0.as_montgomery(), other.0.as_montgomery())
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Hash for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.as_montgomery().hash(state)
     }
@@ -142,6 +155,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Hash for ConstMontyField<Mod, LIMBS
 impl<Mod: Params<LIMBS>, const LIMBS: usize> FromStr for ConstMontyField<Mod, LIMBS> {
     type Err = ();
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let uint = Uint::<LIMBS>::from_str(s)?;
         Ok(Self(ConstMontyForm::new(uint.inner())))
@@ -250,6 +264,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Div for ConstMontyField<Mod, LIMBS>
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Div<&Self> for ConstMontyField<Mod, LIMBS> {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: &Self) -> Self::Output {
         self.checked_div(rhs).expect("Division by zero")
     }
@@ -267,6 +282,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Div for &ConstMontyField<Mod, LIMBS
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Pow<u32> for ConstMontyField<Mod, LIMBS> {
     type Output = Self;
 
+    #[inline(always)]
     fn pow(self, rhs: u32) -> Self::Output {
         Self(self.0.pow(&crypto_bigint::U64::from_u32(rhs)))
     }
@@ -275,6 +291,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Pow<u32> for ConstMontyField<Mod, L
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Inv for ConstMontyField<Mod, LIMBS> {
     type Output = Option<Self>;
 
+    #[inline(always)]
     fn inv(self) -> Self::Output {
         Some(Self(Option::from(self.0.invert_vartime())?))
     }
@@ -287,6 +304,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Inv for ConstMontyField<Mod, LIMBS>
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> CheckedDiv for ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn checked_div(&self, rhs: &Self) -> Option<Self> {
         Some(self * rhs.inv()?)
     }
@@ -299,12 +317,14 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> CheckedDiv for ConstMontyField<Mod,
 macro_rules! impl_field_op_assign {
     ($trait:ident, $method:ident, $inner:ident) => {
         impl<Mod: Params<LIMBS>, const LIMBS: usize> $trait for ConstMontyField<Mod, LIMBS> {
+            #[inline(always)]
             fn $method(&mut self, rhs: Self) {
                 // Use reference for inner call to avoid moves of rhs.0 where not needed
                 *self = self.$inner(&rhs);
             }
         }
         impl<Mod: Params<LIMBS>, const LIMBS: usize> $trait<&Self> for ConstMontyField<Mod, LIMBS> {
+            #[inline(always)]
             fn $method(&mut self, rhs: &Self) {
                 *self = self.$inner(rhs);
             }
@@ -323,6 +343,7 @@ impl_field_op_assign!(DivAssign, div_assign, div);
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Sum for ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
@@ -330,6 +351,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Sum for ConstMontyField<Mod, LIMBS>
 
 impl<'a, Mod: Params<LIMBS>, const LIMBS: usize> Sum<&'a Self> for ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
@@ -337,6 +359,7 @@ impl<'a, Mod: Params<LIMBS>, const LIMBS: usize> Sum<&'a Self> for ConstMontyFie
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Product for ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
@@ -344,6 +367,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Product for ConstMontyField<Mod, LI
 
 impl<'a, Mod: Params<LIMBS>, const LIMBS: usize> Product<&'a Self> for ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
@@ -374,6 +398,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> From<ConstMontyField<Mod, LIMBS>>
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&ConstMontyField<Mod, LIMBS>>
     for ConstMontyField<Mod, LIMBS>
 {
+    #[inline(always)]
     fn from(value: &Self) -> Self {
         *value
     }
@@ -384,6 +409,7 @@ macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
             impl<Mod: Params<LIMBS>, const LIMBS: usize> From<$t> for ConstMontyField<Mod, LIMBS> {
+                #[inline(always)]
                 fn from(value: $t) -> Self {
                     let value = Uint::from(value);
                     Self(ConstMontyForm::new(value.inner()))
@@ -391,6 +417,7 @@ macro_rules! impl_from_unsigned {
             }
 
             impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&$t> for ConstMontyField<Mod, LIMBS> {
+                #[inline(always)]
                 fn from(value: &$t) -> Self {
                     Self::from(*value)
                 }
@@ -405,6 +432,7 @@ macro_rules! impl_from_signed {
         $(
             impl<Mod: Params<LIMBS>, const LIMBS: usize> From<$t> for ConstMontyField<Mod, LIMBS> {
                 #![allow(clippy::arithmetic_side_effects)]
+                #[inline(always)]
                 fn from(value: $t) -> Self {
                     let magnitude = Uint::from(value.abs_diff(0));
                     let form = ConstMontyForm::new(magnitude.inner());
@@ -413,6 +441,7 @@ macro_rules! impl_from_signed {
             }
 
             impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&$t> for ConstMontyField<Mod, LIMBS> {
+                #[inline(always)]
                 fn from(value: &$t) -> Self {
                     Self::from(*value)
                 }
@@ -425,30 +454,35 @@ impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<bool> for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn from(value: bool) -> Self {
         if value { Self::ONE } else { Self::ZERO }
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<Boolean> for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn from(value: Boolean) -> Self {
         Self::from(*value)
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&Boolean> for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn from(value: &Boolean) -> Self {
         Self::from(**value)
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<Uint<LIMBS>> for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn from(value: Uint<LIMBS>) -> Self {
         Self::from(&value)
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&Uint<LIMBS>> for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn from(value: &Uint<LIMBS>) -> Self {
         Self(ConstMontyForm::new(value.inner()))
     }
@@ -457,6 +491,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&Uint<LIMBS>> for ConstMontyFi
 impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<Int<LIMBS2>>
     for ConstMontyField<Mod, LIMBS>
 {
+    #[inline(always)]
     fn from(value: Int<LIMBS2>) -> Self {
         Self::from(value.inner())
     }
@@ -465,6 +500,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<Int<LIMBS
 impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&Int<LIMBS2>>
     for ConstMontyField<Mod, LIMBS>
 {
+    #[inline(always)]
     fn from(value: &Int<LIMBS2>) -> Self {
         Self::from(value.inner())
     }
@@ -473,6 +509,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&Int<LIMB
 impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<crypto_bigint::Int<LIMBS2>>
     for ConstMontyField<Mod, LIMBS>
 {
+    #[inline(always)]
     fn from(value: crypto_bigint::Int<LIMBS2>) -> Self {
         Self::from(&value)
     }
@@ -482,6 +519,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&crypto_b
     for ConstMontyField<Mod, LIMBS>
 {
     #![allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn from(value: &crypto_bigint::Int<LIMBS2>) -> Self {
         assert!(
             LIMBS >= LIMBS2,
@@ -551,6 +589,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstPrimeField for ConstMontyField
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Distribution<ConstMontyField<Mod, LIMBS>>
     for StandardUniform
 {
+    #[inline(always)]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ConstMontyField<Mod, LIMBS> {
         crypto_bigint::Random::random(rng)
     }
@@ -558,6 +597,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Distribution<ConstMontyField<Mod, L
 
 #[cfg(feature = "rand")]
 impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::Random for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         ConstMontyForm::try_random(rng).map(Self)
     }
@@ -602,6 +642,7 @@ where
 //
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstantTimeEq for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
@@ -631,6 +672,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::One for ConstMontyFi
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::Square for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn square(&self) -> Self {
         Self(self.0.square())
     }
@@ -639,6 +681,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::Square for ConstMont
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Retrieve for ConstMontyField<Mod, LIMBS> {
     type Output = Uint<LIMBS>;
 
+    #[inline(always)]
     fn retrieve(&self) -> Self::Output {
         self.retrieve()
     }

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -46,41 +46,49 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
 
     /// Retrieves the integer currently encoded in this [`MontyForm`],
     /// guaranteed to be reduced.
+    #[inline(always)]
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         Uint::new(self.0.retrieve())
     }
 
     /// Access the value in Montgomery form.
+    #[inline(always)]
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
         Uint::new_ref(self.0.as_montgomery())
     }
 
     /// Mutably access the value in Montgomery form.
+    #[inline(always)]
     pub fn as_montgomery_mut(&mut self) -> &mut Uint<LIMBS> {
         Uint::new_ref_mut(self.0.as_montgomery_mut())
     }
 
     /// Create a `MontyField` from a value in Montgomery form.
+    #[inline(always)]
     pub const fn from_montgomery(integer: Uint<LIMBS>, config: &MontyParams<LIMBS>) -> Self {
         Self(MontyForm::from_montgomery(integer.into_inner(), *config))
     }
 
     /// Extract the value from the `MontyForm` in Montgomery form.
+    #[inline(always)]
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
         Uint::new(self.0.to_montgomery())
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[inline(always)]
     pub const fn div_by_2(&self) -> Self {
         Self(self.0.div_by_2())
     }
 
     /// Double `self`.
+    #[inline(always)]
     pub const fn double(&self) -> Self {
         Self(self.0.double())
     }
 
     /// See [MontyForm::pow_bounded_exp].
+    #[inline(always)]
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
@@ -95,12 +103,14 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
 //
 
 impl<const LIMBS: usize> Debug for MontyField<LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Debug::fmt(&self.0, f)
     }
 }
 
 impl<const LIMBS: usize> Display for MontyField<LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(
             f,
@@ -112,6 +122,7 @@ impl<const LIMBS: usize> Display for MontyField<LIMBS> {
 }
 
 impl<const LIMBS: usize> PartialOrd for MontyField<LIMBS> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.modulus() != other.modulus() {
             return None;
@@ -121,6 +132,7 @@ impl<const LIMBS: usize> PartialOrd for MontyField<LIMBS> {
 }
 
 impl<const LIMBS: usize> Hash for MontyField<LIMBS> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.as_montgomery().hash(state)
     }
@@ -133,6 +145,7 @@ impl<const LIMBS: usize> Hash for MontyField<LIMBS> {
 impl<const LIMBS: usize> Neg for MontyField<LIMBS> {
     type Output = Self;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         Self(self.0.neg())
     }
@@ -185,6 +198,7 @@ impl_basic_op!(Mul, mul);
 impl<const LIMBS: usize> Div for MontyField<LIMBS> {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: Self) -> Self::Output {
         self.div(&rhs)
     }
@@ -193,6 +207,7 @@ impl<const LIMBS: usize> Div for MontyField<LIMBS> {
 impl<const LIMBS: usize> Div<&Self> for MontyField<LIMBS> {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: &Self) -> Self::Output {
         self.checked_div(rhs).expect("Division by zero")
     }
@@ -201,6 +216,7 @@ impl<const LIMBS: usize> Div<&Self> for MontyField<LIMBS> {
 impl<const LIMBS: usize> Div for &MontyField<LIMBS> {
     type Output = MontyField<LIMBS>;
 
+    #[inline(always)]
     fn div(self, rhs: Self) -> Self::Output {
         self.checked_div(rhs).expect("Division by zero")
     }
@@ -209,6 +225,7 @@ impl<const LIMBS: usize> Div for &MontyField<LIMBS> {
 impl<const LIMBS: usize> Div<MontyField<LIMBS>> for &MontyField<LIMBS> {
     type Output = MontyField<LIMBS>;
 
+    #[inline(always)]
     fn div(self, rhs: MontyField<LIMBS>) -> Self::Output {
         self.div(&rhs)
     }
@@ -217,6 +234,7 @@ impl<const LIMBS: usize> Div<MontyField<LIMBS>> for &MontyField<LIMBS> {
 impl<const LIMBS: usize> Pow<u32> for MontyField<LIMBS> {
     type Output = Self;
 
+    #[inline(always)]
     fn pow(self, rhs: u32) -> Self::Output {
         Self(self.0.pow(&crypto_bigint::Uint::<1>::from(rhs)))
     }
@@ -225,6 +243,7 @@ impl<const LIMBS: usize> Pow<u32> for MontyField<LIMBS> {
 impl<const LIMBS: usize> Inv for MontyField<LIMBS> {
     type Output = Option<Self>;
 
+    #[inline(always)]
     fn inv(self) -> Self::Output {
         Some(Self(Option::from(self.0.invert_vartime())?))
     }
@@ -233,6 +252,7 @@ impl<const LIMBS: usize> Inv for MontyField<LIMBS> {
 impl<const LIMBS: usize> Inv for &MontyField<LIMBS> {
     type Output = Option<MontyField<LIMBS>>;
 
+    #[inline(always)]
     fn inv(self) -> Self::Output {
         Some(MontyField(Option::from(self.0.invert_vartime())?))
     }
@@ -245,6 +265,7 @@ impl<const LIMBS: usize> Inv for &MontyField<LIMBS> {
 
 impl<const LIMBS: usize> CheckedDiv for MontyField<LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn checked_div(&self, rhs: &Self) -> Option<Self> {
         Some(self * rhs.inv()?)
     }
@@ -257,11 +278,13 @@ impl<const LIMBS: usize> CheckedDiv for MontyField<LIMBS> {
 macro_rules! impl_field_op_assign {
     ($trait:ident, $method:ident) => {
         impl<const LIMBS: usize> $trait for MontyField<LIMBS> {
+            #[inline(always)]
             fn $method(&mut self, rhs: Self) {
                 self.0.$method(&rhs.0);
             }
         }
         impl<const LIMBS: usize> $trait<&Self> for MontyField<LIMBS> {
+            #[inline(always)]
             fn $method(&mut self, rhs: &Self) {
                 self.0.$method(&rhs.0);
             }
@@ -274,12 +297,14 @@ impl_field_op_assign!(SubAssign, sub_assign);
 impl_field_op_assign!(MulAssign, mul_assign);
 
 impl<const LIMBS: usize> DivAssign for MontyField<LIMBS> {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: Self) {
         self.div_assign(&rhs);
     }
 }
 
 impl<const LIMBS: usize> DivAssign<&Self> for MontyField<LIMBS> {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: &Self) {
         self.0.mul_assign(rhs.0.invert().unwrap())
     }
@@ -290,6 +315,7 @@ impl<const LIMBS: usize> DivAssign<&Self> for MontyField<LIMBS> {
 //
 
 impl<const LIMBS: usize> Sum for MontyField<LIMBS> {
+    #[inline(always)]
     fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(MontyField(first)) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for MontyField");
@@ -299,6 +325,7 @@ impl<const LIMBS: usize> Sum for MontyField<LIMBS> {
 }
 
 impl<'a, const LIMBS: usize> Sum<&'a Self> for MontyField<LIMBS> {
+    #[inline(always)]
     fn sum<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(MontyField(first)) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for MontyField");
@@ -308,6 +335,7 @@ impl<'a, const LIMBS: usize> Sum<&'a Self> for MontyField<LIMBS> {
 }
 
 impl<const LIMBS: usize> Product for MontyField<LIMBS> {
+    #[inline(always)]
     fn product<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(MontyField(first)) = iter.next() else {
             panic!("Product of an empty iterator is not defined for MontyField");
@@ -318,6 +346,7 @@ impl<const LIMBS: usize> Product for MontyField<LIMBS> {
 
 impl<'a, const LIMBS: usize> Product<&'a Self> for MontyField<LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn product<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(MontyField(first)) = iter.next() else {
             panic!("Product of an empty iterator is not defined for MontyField");
@@ -345,6 +374,7 @@ impl<const LIMBS: usize> From<MontyField<LIMBS>> for MontyForm<LIMBS> {
 }
 
 impl<const LIMBS: usize> From<&MontyField<LIMBS>> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from(value: &Self) -> Self {
         value.clone()
     }
@@ -354,6 +384,7 @@ macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
             impl<const LIMBS: usize>FromWithConfig<$t> for MontyField<LIMBS> {
+                #[inline(always)]
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let abs: crypto_bigint::Uint<LIMBS> = value.into();
                     Self(MontyForm::<LIMBS>::new(&abs, *cfg))
@@ -361,6 +392,7 @@ macro_rules! impl_from_unsigned {
             }
 
             impl<const LIMBS: usize>FromWithConfig<&$t> for MontyField<LIMBS> {
+                #[inline(always)]
                 fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
                     Self::from_with_cfg(*value, cfg)
                 }
@@ -374,6 +406,7 @@ macro_rules! impl_from_signed {
         $(
             #[allow(clippy::arithmetic_side_effects)] // False alert
             impl<const LIMBS: usize>FromWithConfig<$t> for MontyField<LIMBS> {
+                #[inline(always)]
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let magnitude = Uint::from(value.abs_diff(0));
                     let form = MontyForm::new(magnitude.inner(), cfg.clone());
@@ -382,6 +415,7 @@ macro_rules! impl_from_signed {
             }
 
             impl<const LIMBS: usize>FromWithConfig<&$t> for MontyField<LIMBS> {
+                #[inline(always)]
                 fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
                     Self::from_with_cfg(*value, cfg)
                 }
@@ -394,6 +428,7 @@ impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
 impl<const LIMBS: usize> FromWithConfig<bool> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from_with_cfg(value: bool, cfg: &Self::Config) -> Self {
         let abs = if value {
             crypto_bigint::Uint::one()
@@ -405,24 +440,28 @@ impl<const LIMBS: usize> FromWithConfig<bool> for MontyField<LIMBS> {
 }
 
 impl<const LIMBS: usize> FromWithConfig<&bool> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from_with_cfg(value: &bool, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }
 
 impl<const LIMBS: usize> FromWithConfig<Boolean> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from_with_cfg(value: Boolean, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }
 
 impl<const LIMBS: usize> FromWithConfig<&Boolean> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from_with_cfg(value: &Boolean, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }
 
 impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<Int<LIMBS2>> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from_with_cfg(value: Int<LIMBS2>, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(&value, cfg)
     }
@@ -430,6 +469,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<Int<LIMBS2>> for Mo
 
 impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Int<LIMBS2>> for MontyField<LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn from_with_cfg(value: &Int<LIMBS2>, cfg: &Self::Config) -> Self {
         let mut abs = value.inner().abs();
         if LIMBS < LIMBS2 {
@@ -444,6 +484,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Int<LIMBS2>> for M
 }
 
 impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<Uint<LIMBS2>> for MontyField<LIMBS> {
+    #[inline(always)]
     fn from_with_cfg(value: Uint<LIMBS2>, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(&value, cfg)
     }
@@ -451,6 +492,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<Uint<LIMBS2>> for M
 
 impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Uint<LIMBS2>> for MontyField<LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn from_with_cfg(value: &Uint<LIMBS2>, cfg: &Self::Config) -> Self {
         if LIMBS >= LIMBS2 {
             Self::new(MontyForm::new(&value.inner().resize(), *cfg))
@@ -493,15 +535,18 @@ impl<const LIMBS: usize> Field for MontyField<LIMBS> {
 impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
     type Config = MontyParams<LIMBS>;
 
+    #[inline(always)]
     fn cfg(&self) -> &Self::Config {
         self.0.params()
     }
 
+    #[inline(always)]
     fn modulus(&self) -> Self::Inner {
         Uint::new(self.0.params().modulus().get())
     }
 
     #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn modulus_minus_one_div_two(&self) -> Self::Inner {
         let value = self.0.params().modulus().get();
         Uint::new(
@@ -510,6 +555,7 @@ impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
         )
     }
 
+    #[inline(always)]
     fn make_cfg(modulus: &Self::Inner) -> Result<Self::Config, FieldError> {
         let Some(modulus) = Odd::new(*modulus.inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
@@ -517,22 +563,27 @@ impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
         Ok(MontyParams::new(modulus))
     }
 
+    #[inline(always)]
     fn new_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
         Self(MontyForm::new(inner.inner(), *cfg))
     }
 
+    #[inline(always)]
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
         Self(MontyForm::from_montgomery(inner.into_inner(), *cfg))
     }
 
+    #[inline(always)]
     fn zero_with_cfg(cfg: &Self::Config) -> Self {
         Self(MontyForm::zero(*cfg))
     }
 
+    #[inline(always)]
     fn is_zero_with_cfg(&self, _cfg: &Self::Config) -> bool {
         self.0.as_montgomery().is_zero()
     }
 
+    #[inline(always)]
     fn one_with_cfg(cfg: &Self::Config) -> Self {
         Self(MontyForm::one(*cfg))
     }

--- a/src/semiring/boolean.rs
+++ b/src/semiring/boolean.rs
@@ -152,7 +152,7 @@ macro_rules! impl_from_boolean_for {
         impl From<Boolean> for $to {
             #[inline(always)]
             fn from(value: Boolean) -> Self {
-                value.0 as $to
+                <$to>::from(value.0)
             }
         }
     )*};


### PR DESCRIPTION
The methods of monty fields are mostly delegates so let's inline(always) probably?