### PR TITLE
Prime field lifting to integers

### DIFF
--- a/benches/field_ops_bench_common.rs
+++ b/benches/field_ops_bench_common.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use criterion::{AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration};
-use crypto_primitives::FromPrimitiveWithConfig;
+use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 
 fn bench_random_field<F>(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
@@ -16,7 +16,7 @@ fn bench_random_field<F>(
     config: &F::Config,
 ) where
     for<'a> &'a F: Add<&'a F> + Mul<&'a F> + Div<&'a F>,
-    F: FromPrimitiveWithConfig + for<'a> Sum<&'a F> + for<'a> Product<&'a F>,
+    F: PrimeField + FromPrimitiveWithConfig + for<'a> Sum<&'a F> + for<'a> Product<&'a F>,
 {
     let field_elem = F::from_with_cfg(num, config);
     let param = format!("Param = {}", num);
@@ -221,7 +221,7 @@ fn bench_random_field<F>(
 pub fn field_benchmarks<F>(c: &mut Criterion, name: &str, config: &F::Config)
 where
     for<'a> &'a F: Add<&'a F> + Mul<&'a F> + Div<&'a F>,
-    F: FromPrimitiveWithConfig + for<'a> Sum<&'a F> + for<'a> Product<&'a F>,
+    F: PrimeField + FromPrimitiveWithConfig + for<'a> Sum<&'a F> + for<'a> Product<&'a F>,
 {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -38,18 +38,23 @@ pub trait Field:
     + for<'a> Div<&'a Self, Output=Self>
     + for<'a> DivAssign<&'a Self>
 {
-    /// Underlying representation of an element
-    type Inner: Debug + Eq + Clone + Sync + Send;
-
     /// A semiring integer type that's used to represent the value of this field when lifted to integers.
     /// Also used to represent modulus in prime fields.
     type Integer: Semiring;
+
+    /// Type of the underlying representation of this field element. This type might differ from [`Self::Integer`],
+    /// and is *NOT* guaranteed to be normalized.
+    /// Should only be used to reconstruct the field using [`ConstPrimeField::new_unchecked`] and
+    /// [`PrimeField::new_unchecked_with_cfg`] (with the same config supplied!).
+    type Inner: Debug + Eq + Clone + Sync + Send;
 
     fn inner(&self) -> &Self::Inner;
     fn inner_mut(&mut self) -> &mut Self::Inner;
     fn into_inner(self) -> Self::Inner;
 
-    /// Lift the field element to integer semiring using a natural approach. Can be projected back to the field.
+    /// Lift the field element to integer semiring using a natural approach.
+    ///
+    /// Can be projected back to the field using [`FromWithConfig::from_with_cfg`] to get the same field element.
     fn lift_to_integer(self) -> Self::Integer;
 }
 
@@ -81,16 +86,9 @@ pub trait PrimeField: Field + HasPrimeFieldConfig + FromWithConfig<Self::Integer
 
     fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError>;
 
-    /// Creates a new instance of a prime field element from
-    /// an arbitrary element of `Self::Inner`. The method
-    /// should not assume the `Self::Inner` is coming in a
-    /// form internally used by the field type. So it
-    /// always should perform a reduction first.
-    fn new_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self;
-
     /// Creates a new instance of the prime field element from a representation
     /// known to be valid - should consume exactly the value returned by
-    /// `inner()`. Ideally, this should not check the validity of the
+    /// [`Self::inner()`]. Ideally, this should not check the validity of the
     /// element, but it's acceptable to perform a check if it can't be
     /// avoided.
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self;
@@ -112,13 +110,6 @@ pub trait ConstPrimeField:
 {
     const MODULUS: Self::Integer;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner;
-
-    /// Creates a new instance of a prime field element from
-    /// an arbitrary element of `Self::Inner`. The method
-    /// should not assume the `Self::Inner` is coming in a
-    /// form internally used by the field type. So it
-    /// always should perform a reduction first.
-    fn new(inner: Self::Inner) -> Self;
 
     /// Creates a new instance of the prime field element from a representation
     /// known to be valid - should consume exactly the value returned by
@@ -159,11 +150,6 @@ impl<T: ConstPrimeField> PrimeField for T {
         } else {
             Err(FieldError::InvalidModulus)
         }
-    }
-
-    #[inline(always)]
-    fn new_with_cfg(inner: Self::Inner, _cfg: &Self::Config) -> Self {
-        ConstPrimeField::new(inner)
     }
 
     #[inline(always)]

--- a/src/field.rs
+++ b/src/field.rs
@@ -82,7 +82,7 @@ pub trait PrimeField: Field + HasPrimeFieldConfig + FromWithConfig<Self::Integer
 
     fn modulus(&self) -> Self::Integer;
 
-    fn modulus_minus_one_div_two(&self) -> Self::Inner;
+    fn modulus_minus_one_div_two(&self) -> Self::Integer;
 
     fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError>;
 
@@ -109,7 +109,7 @@ pub trait ConstPrimeField:
     + From<Self::Integer>
 {
     const MODULUS: Self::Integer;
-    const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner;
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;
 
     /// Creates a new instance of the prime field element from a representation
     /// known to be valid - should consume exactly the value returned by
@@ -140,7 +140,7 @@ impl<T: ConstPrimeField> PrimeField for T {
     }
 
     #[inline(always)]
-    fn modulus_minus_one_div_two(&self) -> T::Inner {
+    fn modulus_minus_one_div_two(&self) -> Self::Integer {
         Self::MODULUS_MINUS_ONE_DIV_TWO
     }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -55,7 +55,7 @@ pub trait Field:
     /// Lift the field element to integer semiring using a natural approach.
     ///
     /// Can be projected back to the field using [`FromWithConfig::from_with_cfg`] to get the same field element.
-    fn lift_to_integer(self) -> Self::Integer;
+    fn lift_to_integer(&self) -> Self::Integer;
 }
 
 /// A helper supertrait for prime fields, allows decoupling of

--- a/src/field.rs
+++ b/src/field.rs
@@ -12,7 +12,7 @@ pub(crate) mod crypto_bigint_helpers;
 pub mod crypto_bigint_monty;
 pub mod f2;
 
-use crate::{ConstSemiring, ring::Ring};
+use crate::{ConstSemiring, Semiring, ring::Ring};
 use core::{
     fmt::Debug,
     ops::{Div, DivAssign, Neg},
@@ -46,9 +46,15 @@ pub trait Field:
     /// (e.g. F2 where elements are `bool` but the modulus is `2: u8`).
     type Modulus: Debug + Eq + Clone + Sync + Send;
 
+    /// A semiring integer type that's used to represent the value of this field when lifted to integers.
+    type LiftedInt: Semiring;
+
     fn inner(&self) -> &Self::Inner;
     fn inner_mut(&mut self) -> &mut Self::Inner;
     fn into_inner(self) -> Self::Inner;
+
+    /// Lift the field element to integer semiring by discarding the modulus.
+    fn lift_to_integer(self) -> Self::LiftedInt;
 }
 
 /// Element of an integer field modulo prime number (F_p).

--- a/src/field.rs
+++ b/src/field.rs
@@ -73,7 +73,7 @@ pub trait HasPrimeFieldConfig {
 /// Prime modulus might be dynamic and can be determined at runtime.
 ///
 /// When performing arithmetic operations, the modulus of both operands must be
-/// the same, otherwise operations should panic.
+/// the same, otherwise operations should panic in debug mode.
 ///
 /// Constant prime fields are considered a special case of dynamic prime fields.
 pub trait PrimeField: Field + HasPrimeFieldConfig + FromWithConfig<Self::Integer> {

--- a/src/field.rs
+++ b/src/field.rs
@@ -41,20 +41,27 @@ pub trait Field:
     /// Underlying representation of an element
     type Inner: Debug + Eq + Clone + Sync + Send;
 
-    /// Type used to represent the modulus. Usually the same as `Self::Inner`,
-    /// but may differ when the modulus doesn't fit in the element representation
-    /// (e.g. F2 where elements are `bool` but the modulus is `2: u8`).
-    type Modulus: Debug + Eq + Clone + Sync + Send;
-
     /// A semiring integer type that's used to represent the value of this field when lifted to integers.
-    type LiftedInt: Semiring;
+    /// Also used to represent modulus in prime fields.
+    type Integer: Semiring;
 
     fn inner(&self) -> &Self::Inner;
     fn inner_mut(&mut self) -> &mut Self::Inner;
     fn into_inner(self) -> Self::Inner;
 
-    /// Lift the field element to integer semiring by discarding the modulus.
-    fn lift_to_integer(self) -> Self::LiftedInt;
+    /// Lift the field element to integer semiring using a natural approach. Can be projected back to the field.
+    fn lift_to_integer(self) -> Self::Integer;
+}
+
+/// A helper supertrait for prime fields, allows decoupling of
+/// [`FromWithConfig`].
+pub trait HasPrimeFieldConfig {
+    /// Runtime configuration for the prime field, empty for constant prime
+    /// fields. For dynamic prime fields, it could be just modulus or more
+    /// complex structure.
+    type Config: Debug + Clone + Send + Sync + 'static;
+
+    fn cfg(&self) -> &Self::Config;
 }
 
 /// Element of an integer field modulo prime number (F_p).
@@ -64,22 +71,15 @@ pub trait Field:
 /// the same, otherwise operations should panic.
 ///
 /// Constant prime fields are considered a special case of dynamic prime fields.
-pub trait PrimeField: Field {
-    /// Runtime configuration for the prime field, empty for constant prime
-    /// fields. For dynamic prime fields, it could be just modulus or more
-    /// complex structure.
-    type Config: Debug + Clone + Send + Sync + 'static;
-
-    fn cfg(&self) -> &Self::Config;
-
+pub trait PrimeField: Field + HasPrimeFieldConfig + FromWithConfig<Self::Integer> {
     // Note: Not using `&self` to avoid conflicts with `Zero` trait.
     fn is_zero(value: &Self) -> bool;
 
-    fn modulus(&self) -> Self::Modulus;
+    fn modulus(&self) -> Self::Integer;
 
     fn modulus_minus_one_div_two(&self) -> Self::Inner;
 
-    fn make_cfg(modulus: &Self::Modulus) -> Result<Self::Config, FieldError>;
+    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError>;
 
     /// Creates a new instance of a prime field element from
     /// an arbitrary element of `Self::Inner`. The method
@@ -102,9 +102,15 @@ pub trait PrimeField: Field {
 
 /// Prime field whose modulus is a constant value known at compile time.
 pub trait ConstPrimeField:
-    Field + ConstSemiring + Inv<Output = Option<Self>> + From<u64> + From<u128> + From<Self::Inner>
+    Field
+    + ConstSemiring
+    + Inv<Output = Option<Self>>
+    + From<u64>
+    + From<u128>
+    + From<Self::Inner>
+    + From<Self::Integer>
 {
-    const MODULUS: Self::Modulus;
+    const MODULUS: Self::Integer;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner;
 
     /// Creates a new instance of a prime field element from
@@ -122,21 +128,23 @@ pub trait ConstPrimeField:
     fn new_unchecked(inner: Self::Inner) -> Self;
 }
 
-impl<T: ConstPrimeField> PrimeField for T {
+impl<T: ConstPrimeField> HasPrimeFieldConfig for T {
     /// For constant prime fields, the configuration is empty.
     type Config = ();
 
     fn cfg(&self) -> &Self::Config {
         &()
     }
+}
 
+impl<T: ConstPrimeField> PrimeField for T {
     #[inline(always)]
     fn is_zero(value: &Self) -> bool {
         Zero::is_zero(value)
     }
 
     #[inline(always)]
-    fn modulus(&self) -> Self::Modulus {
+    fn modulus(&self) -> Self::Integer {
         Self::MODULUS
     }
 
@@ -145,7 +153,7 @@ impl<T: ConstPrimeField> PrimeField for T {
         Self::MODULUS_MINUS_ONE_DIV_TWO
     }
 
-    fn make_cfg(modulus: &Self::Modulus) -> Result<Self::Config, FieldError> {
+    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
         if *modulus == Self::MODULUS {
             Ok(())
         } else {
@@ -185,7 +193,7 @@ pub trait MontgomeryField: PrimeField {
 }
 
 /// Analogous to `From` trait, but with a prime field configuration parameter.
-pub trait FromWithConfig<T>: PrimeField {
+pub trait FromWithConfig<T>: HasPrimeFieldConfig {
     fn from_with_cfg(value: T, cfg: &Self::Config) -> Self;
 }
 

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::{Semiring, boolean::Boolean};
+use crate::{Semiring, boolean::Boolean, semiring::ark_ff_bigint::BigInt};
 use ark_ff::{
-    AdditiveGroup, CubicExtConfig, CubicExtField, LegendreSymbol, QuadExtConfig, QuadExtField,
-    SqrtPrecomputation, fields::Field as ArkWrappedField,
+    AdditiveGroup, FftField, LegendreSymbol, SqrtPrecomputation,
+    fields::{Field as ArkWrappedField, PrimeField as ArkWrappedPrimeField},
 };
 use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
@@ -13,7 +13,7 @@ use core::{
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Deref, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
     str::FromStr,
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
@@ -30,9 +30,9 @@ use rand::distr::StandardUniform;
 #[infallible_checked_unary_op((CheckedNeg, neg))]
 #[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
 #[repr(transparent)]
-pub struct ArkField<F: ArkWrappedField>(F);
+pub struct ArkField<F: ArkWrappedPrimeField>(F);
 
-impl<F: ArkWrappedField> ArkField<F> {
+impl<F: ArkWrappedPrimeField> ArkField<F> {
     /// Wraps a given value into this wrapper type
     #[inline(always)]
     pub const fn new(value: F) -> Self {
@@ -53,71 +53,50 @@ impl<F: ArkWrappedField> ArkField<F> {
     }
 }
 
-impl<P: QuadExtConfig> ArkField<QuadExtField<P>> {
-    pub const fn new_ext(c0: P::BaseField, c1: P::BaseField) -> Self {
-        Self(QuadExtField::<P>::new(c0, c1))
-    }
-}
-
-impl<P: CubicExtConfig> ArkField<CubicExtField<P>> {
-    pub const fn new_ext(c0: P::BaseField, c1: P::BaseField, c2: P::BaseField) -> Self {
-        Self(CubicExtField::<P>::new(c0, c1, c2))
-    }
-}
-
 //
 // Core traits
 //
 
-impl<F: ArkWrappedField> Debug for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Debug for ArkField<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Debug::fmt(&self.0, f)
     }
 }
 
-impl<F: ArkWrappedField> Display for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Display for ArkField<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", self.0)
     }
 }
 
-impl<F: ArkWrappedField> Default for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Default for ArkField<F> {
     #[inline(always)]
     fn default() -> Self {
         Self::zero()
     }
 }
 
-impl<F: ArkWrappedField> Deref for ArkField<F> {
-    type Target = F;
-
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        self.inner()
-    }
-}
-
-impl<F: ArkWrappedField> PartialOrd for ArkField<F> {
+impl<F: ArkWrappedPrimeField> PartialOrd for ArkField<F> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<F: ArkWrappedField> Ord for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Ord for ArkField<F> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         Ord::cmp(&self.0, &other.0)
     }
 }
 
-impl<F: ArkWrappedField> Hash for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Hash for ArkField<F> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state)
     }
 }
 
-impl<F: ArkWrappedField + FromStr> FromStr for ArkField<F> {
+impl<F: ArkWrappedPrimeField + FromStr> FromStr for ArkField<F> {
     type Err = <F as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -129,7 +108,7 @@ impl<F: ArkWrappedField + FromStr> FromStr for ArkField<F> {
 // Zero and One traits
 //
 
-impl<F: ArkWrappedField> Zero for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Zero for ArkField<F> {
     #[inline]
     fn zero() -> Self {
         Self(F::zero())
@@ -141,18 +120,18 @@ impl<F: ArkWrappedField> Zero for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> One for ArkField<F> {
+impl<F: ArkWrappedPrimeField> One for ArkField<F> {
     #[inline(always)]
     fn one() -> Self {
         Self(F::one())
     }
 }
 
-impl<F: ArkWrappedField> ConstZero for ArkField<F> {
+impl<F: ArkWrappedPrimeField> ConstZero for ArkField<F> {
     const ZERO: Self = Self(<F as AdditiveGroup>::ZERO);
 }
 
-impl<F: ArkWrappedField> ConstOne for ArkField<F> {
+impl<F: ArkWrappedPrimeField> ConstOne for ArkField<F> {
     const ONE: Self = Self(F::ONE);
 }
 
@@ -160,7 +139,7 @@ impl<F: ArkWrappedField> ConstOne for ArkField<F> {
 // Basic arithmetic operations
 //
 
-impl<F: ArkWrappedField> Neg for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Neg for ArkField<F> {
     type Output = Self;
 
     #[inline(always)]
@@ -171,7 +150,7 @@ impl<F: ArkWrappedField> Neg for ArkField<F> {
 
 macro_rules! impl_basic_op {
     ($trait:ident, $method:ident) => {
-        impl<F: ArkWrappedField> $trait for ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait for ArkField<F> {
             type Output = Self;
 
             #[inline(always)]
@@ -180,7 +159,7 @@ macro_rules! impl_basic_op {
             }
         }
 
-        impl<F: ArkWrappedField> $trait<&Self> for ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait<&Self> for ArkField<F> {
             type Output = Self;
 
             #[inline(always)]
@@ -189,7 +168,7 @@ macro_rules! impl_basic_op {
             }
         }
 
-        impl<F: ArkWrappedField> $trait<&mut Self> for ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait<&mut Self> for ArkField<F> {
             type Output = Self;
 
             #[inline(always)]
@@ -198,7 +177,7 @@ macro_rules! impl_basic_op {
             }
         }
 
-        impl<F: ArkWrappedField> $trait for &ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait for &ArkField<F> {
             type Output = ArkField<F>;
 
             #[inline(always)]
@@ -207,7 +186,7 @@ macro_rules! impl_basic_op {
             }
         }
 
-        impl<F: ArkWrappedField> $trait<ArkField<F>> for &ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait<ArkField<F>> for &ArkField<F> {
             type Output = ArkField<F>;
 
             #[inline(always)]
@@ -222,7 +201,7 @@ impl_basic_op!(Add, add);
 impl_basic_op!(Sub, sub);
 impl_basic_op!(Mul, mul);
 
-impl<F: ArkWrappedField> Div for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Div for ArkField<F> {
     type Output = Self;
 
     #[inline(always)]
@@ -231,7 +210,7 @@ impl<F: ArkWrappedField> Div for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> Div<&Self> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Div<&Self> for ArkField<F> {
     type Output = Self;
 
     fn div(self, rhs: &Self) -> Self::Output {
@@ -239,7 +218,7 @@ impl<F: ArkWrappedField> Div<&Self> for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> Div<&mut Self> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Div<&mut Self> for ArkField<F> {
     type Output = Self;
 
     #[inline(always)]
@@ -248,7 +227,7 @@ impl<F: ArkWrappedField> Div<&mut Self> for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> Pow<u32> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Pow<u32> for ArkField<F> {
     type Output = Self;
 
     fn pow(self, rhs: u32) -> Self::Output {
@@ -256,7 +235,7 @@ impl<F: ArkWrappedField> Pow<u32> for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> Inv for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Inv for ArkField<F> {
     type Output = Option<Self>;
 
     fn inv(mut self) -> Self::Output {
@@ -270,7 +249,7 @@ impl<F: ArkWrappedField> Inv for ArkField<F> {
 // (Note: Field operations do not overflow)
 //
 
-impl<F: ArkWrappedField> CheckedDiv for ArkField<F> {
+impl<F: ArkWrappedPrimeField> CheckedDiv for ArkField<F> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn checked_div(&self, rhs: &Self) -> Option<Self> {
         rhs.0.inverse().map(|inv| Self(self.0 * inv))
@@ -283,20 +262,20 @@ impl<F: ArkWrappedField> CheckedDiv for ArkField<F> {
 
 macro_rules! impl_field_op_assign {
     ($trait:ident, $method:ident, $inner:ident) => {
-        impl<F: ArkWrappedField> $trait for ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait for ArkField<F> {
             fn $method(&mut self, rhs: Self) {
                 // Use reference for inner call to avoid moves of rhs.0 where not needed
                 *self = self.$inner(&rhs);
             }
         }
 
-        impl<F: ArkWrappedField> $trait<&Self> for ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait<&Self> for ArkField<F> {
             fn $method(&mut self, rhs: &Self) {
                 *self = self.$inner(rhs);
             }
         }
 
-        impl<F: ArkWrappedField> $trait<&mut Self> for ArkField<F> {
+        impl<F: ArkWrappedPrimeField> $trait<&mut Self> for ArkField<F> {
             fn $method(&mut self, rhs: &mut Self) {
                 *self = self.$inner(rhs);
             }
@@ -313,28 +292,28 @@ impl_field_op_assign!(DivAssign, div_assign, div);
 // Aggregate operations
 //
 
-impl<F: ArkWrappedField> Sum for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Sum for ArkField<F> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |acc, x| acc + x)
     }
 }
 
-impl<'a, F: ArkWrappedField> Sum<&'a Self> for ArkField<F> {
+impl<'a, F: ArkWrappedPrimeField> Sum<&'a Self> for ArkField<F> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |acc, x| acc + x)
     }
 }
 
-impl<F: ArkWrappedField> Product for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Product for ArkField<F> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::one(), |acc, x| acc * x)
     }
 }
 
-impl<'a, F: ArkWrappedField> Product<&'a Self> for ArkField<F> {
+impl<'a, F: ArkWrappedPrimeField> Product<&'a Self> for ArkField<F> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::one(), |acc, x| acc * x)
@@ -345,7 +324,7 @@ impl<'a, F: ArkWrappedField> Product<&'a Self> for ArkField<F> {
 // Conversions
 //
 
-impl<F: ArkWrappedField> From<&ArkField<F>> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> From<&ArkField<F>> for ArkField<F> {
     fn from(value: &Self) -> Self {
         *value
     }
@@ -354,13 +333,13 @@ impl<F: ArkWrappedField> From<&ArkField<F>> for ArkField<F> {
 macro_rules! impl_from_delegate {
     ($($t:ty),* $(,)?) => {
         $(
-            impl<F: ArkWrappedField> From<$t> for ArkField<F> {
+            impl<F: ArkWrappedPrimeField> From<$t> for ArkField<F> {
                 fn from(value: $t) -> Self {
                     Self(F::from(value))
                 }
             }
 
-            impl<F: ArkWrappedField> From<&$t> for ArkField<F> {
+            impl<F: ArkWrappedPrimeField> From<&$t> for ArkField<F> {
                 fn from(value: &$t) -> Self {
                     Self::from(*value)
                 }
@@ -372,21 +351,57 @@ macro_rules! impl_from_delegate {
 impl_from_delegate!(u8, u16, u32, u64, u128);
 impl_from_delegate!(i8, i16, i32, i64, i128);
 
-impl<F: ArkWrappedField> From<bool> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> From<bool> for ArkField<F> {
     fn from(value: bool) -> Self {
         if value { Self::one() } else { Self::zero() }
     }
 }
 
-impl<F: ArkWrappedField> From<Boolean> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> From<Boolean> for ArkField<F> {
     fn from(value: Boolean) -> Self {
         Self::from(*value)
     }
 }
 
-impl<F: ArkWrappedField> From<&Boolean> for ArkField<F> {
+impl<F: ArkWrappedPrimeField> From<&Boolean> for ArkField<F> {
     fn from(value: &Boolean) -> Self {
         Self::from(**value)
+    }
+}
+
+impl<F: ArkWrappedPrimeField + From<ark_ff::BigInt<N>>, const N: usize> From<ark_ff::BigInt<N>>
+    for ArkField<F>
+{
+    fn from(value: ark_ff::BigInt<N>) -> Self {
+        Self(F::from(value))
+    }
+}
+
+impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>> From<num_bigint::BigUint>
+    for ArkField<F>
+{
+    fn from(value: num_bigint::BigUint) -> Self {
+        Self(F::from(value))
+    }
+}
+
+//
+// Reverse From traits, required by ark-ff Field
+//
+
+impl<F: ArkWrappedPrimeField + Into<ark_ff::BigInt<N>>, const N: usize> From<ArkField<F>>
+    for ark_ff::BigInt<N>
+{
+    fn from(value: ArkField<F>) -> Self {
+        value.0.into()
+    }
+}
+
+impl<F: ArkWrappedPrimeField + Into<num_bigint::BigUint>> From<ArkField<F>>
+    for num_bigint::BigUint
+{
+    fn from(value: ArkField<F>) -> Self {
+        value.0.into()
     }
 }
 
@@ -394,12 +409,16 @@ impl<F: ArkWrappedField> From<&Boolean> for ArkField<F> {
 // Semiring, Ring and Field
 //
 
-impl<F: ArkWrappedField> Semiring for ArkField<F> {}
+impl<F: ArkWrappedPrimeField> Semiring for ArkField<F> {}
 
-impl<F: ArkWrappedField> Ring for ArkField<F> {}
+impl<F: ArkWrappedPrimeField> Ring for ArkField<F> {}
 
-impl<F: ArkWrappedField> Field for ArkField<F> {
+impl<F, const N: usize> Field for ArkField<F>
+where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
+{
     type Inner = F;
+    type LiftedInt = BigInt<N>;
     type Modulus = <F::BasePrimeField as ark_ff::PrimeField>::BigInt;
 
     #[inline(always)]
@@ -416,6 +435,11 @@ impl<F: ArkWrappedField> Field for ArkField<F> {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    #[inline(always)]
+    fn lift_to_integer(self) -> Self::LiftedInt {
+        BigInt::new(self.0.into_bigint())
+    }
 }
 
 //
@@ -423,14 +447,14 @@ impl<F: ArkWrappedField> Field for ArkField<F> {
 //
 
 #[cfg(feature = "rand")]
-impl<F: ArkWrappedField> Distribution<ArkField<F>> for StandardUniform {
+impl<F: ArkWrappedPrimeField> Distribution<ArkField<F>> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ArkField<F> {
         ArkField(UniformRand::rand(rng))
     }
 }
 
 #[cfg(feature = "rand")]
-impl<F: ArkWrappedField> UniformRand for ArkField<F> {
+impl<F: ArkWrappedPrimeField> UniformRand for ArkField<F> {
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         Self(F::rand(rng))
     }
@@ -441,7 +465,7 @@ impl<F: ArkWrappedField> UniformRand for ArkField<F> {
 //
 
 #[cfg(feature = "zeroize")]
-impl<F: ArkWrappedField> zeroize::Zeroize for ArkField<F> {
+impl<F: ArkWrappedPrimeField> zeroize::Zeroize for ArkField<F> {
     fn zeroize(&mut self) {
         self.0.zeroize()
     }
@@ -451,7 +475,7 @@ impl<F: ArkWrappedField> zeroize::Zeroize for ArkField<F> {
 // Traits from ark-ff
 //
 
-impl<F: ArkWrappedField> CanonicalSerialize for ArkField<F> {
+impl<F: ArkWrappedPrimeField> CanonicalSerialize for ArkField<F> {
     fn serialize_with_mode<W: Write>(
         &self,
         writer: W,
@@ -465,7 +489,7 @@ impl<F: ArkWrappedField> CanonicalSerialize for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> CanonicalSerializeWithFlags for ArkField<F> {
+impl<F: ArkWrappedPrimeField> CanonicalSerializeWithFlags for ArkField<F> {
     fn serialize_with_flags<W: Write, G: Flags>(
         &self,
         writer: W,
@@ -479,7 +503,7 @@ impl<F: ArkWrappedField> CanonicalSerializeWithFlags for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> CanonicalDeserialize for ArkField<F> {
+impl<F: ArkWrappedPrimeField> CanonicalDeserialize for ArkField<F> {
     fn deserialize_with_mode<R: Read>(
         reader: R,
         compress: Compress,
@@ -489,7 +513,7 @@ impl<F: ArkWrappedField> CanonicalDeserialize for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> CanonicalDeserializeWithFlags for ArkField<F> {
+impl<F: ArkWrappedPrimeField> CanonicalDeserializeWithFlags for ArkField<F> {
     fn deserialize_with_flags<R: Read, G: Flags>(
         reader: R,
     ) -> Result<(Self, G), SerializationError> {
@@ -497,20 +521,82 @@ impl<F: ArkWrappedField> CanonicalDeserializeWithFlags for ArkField<F> {
     }
 }
 
-impl<F: ArkWrappedField> Valid for ArkField<F> {
+impl<F: ArkWrappedPrimeField> Valid for ArkField<F> {
     fn check(&self) -> Result<(), SerializationError> {
         self.0.check()
     }
 }
 
-impl<F: ArkWrappedField> AdditiveGroup for ArkField<F> {
+impl<F> AdditiveGroup for ArkField<F>
+where
+    F: ArkWrappedPrimeField,
+    Self: From<F::BigInt> + Into<F::BigInt>,
+{
     type Scalar = Self;
 
     const ZERO: Self = <Self as ConstZero>::ZERO;
 }
 
-impl<F: ArkWrappedField> ArkWrappedField for ArkField<F> {
-    type BasePrimeField = F::BasePrimeField;
+impl<F> FftField for ArkField<F>
+where
+    F: ArkWrappedPrimeField,
+    Self: From<F::BigInt> + Into<F::BigInt>,
+{
+    const GENERATOR: Self = Self(F::GENERATOR);
+    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> = match F::LARGE_SUBGROUP_ROOT_OF_UNITY {
+        None => None,
+        Some(root) => Some(Self(root)),
+    };
+    const SMALL_SUBGROUP_BASE: Option<u32> = F::SMALL_SUBGROUP_BASE;
+    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = F::SMALL_SUBGROUP_BASE_ADICITY;
+    const TWO_ADICITY: u32 = F::TWO_ADICITY;
+    const TWO_ADIC_ROOT_OF_UNITY: Self = Self(F::TWO_ADIC_ROOT_OF_UNITY);
+
+    fn get_root_of_unity(n: u64) -> Option<Self> {
+        F::get_root_of_unity(n).map(Self)
+    }
+}
+
+impl<F> ArkWrappedPrimeField for ArkField<F>
+where
+    F: ArkWrappedPrimeField,
+    Self: From<F::BigInt> + Into<F::BigInt>,
+{
+    type BigInt = F::BigInt;
+
+    const MODULUS: Self::BigInt = F::MODULUS;
+    const MODULUS_BIT_SIZE: u32 = F::MODULUS_BIT_SIZE;
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::BigInt = F::MODULUS_MINUS_ONE_DIV_TWO;
+    const TRACE: Self::BigInt = F::TRACE;
+    const TRACE_MINUS_ONE_DIV_TWO: Self::BigInt = F::TRACE_MINUS_ONE_DIV_TWO;
+
+    #[inline(always)]
+    fn from_bigint(repr: Self::BigInt) -> Option<Self> {
+        <F as ArkWrappedPrimeField>::from_bigint(repr).map(Self)
+    }
+
+    #[inline(always)]
+    fn into_bigint(self) -> Self::BigInt {
+        self.0.into_bigint()
+    }
+
+    #[inline(always)]
+    fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
+        Self::new(F::from_be_bytes_mod_order(bytes))
+    }
+
+    #[inline(always)]
+    fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
+        Self::new(F::from_le_bytes_mod_order(bytes))
+    }
+}
+
+impl<F> ArkWrappedField for ArkField<F>
+where
+    F: ArkWrappedPrimeField,
+    Self: From<F::BigInt> + Into<F::BigInt>,
+{
+    type BasePrimeField = Self;
 
     const ONE: Self = <Self as ConstOne>::ONE;
     const SQRT_PRECOMP: Option<SqrtPrecomputation<Self>> = {
@@ -544,17 +630,17 @@ impl<F: ArkWrappedField> ArkWrappedField for ArkField<F> {
     }
 
     fn to_base_prime_field_elements(&self) -> impl Iterator<Item = Self::BasePrimeField> {
-        self.0.to_base_prime_field_elements()
+        self.0.to_base_prime_field_elements().map(Self)
     }
 
     fn from_base_prime_field_elems(
         elems: impl IntoIterator<Item = Self::BasePrimeField>,
     ) -> Option<Self> {
-        F::from_base_prime_field_elems(elems).map(Self)
+        F::from_base_prime_field_elems(elems.into_iter().map(|v| v.0)).map(Self)
     }
 
     fn from_base_prime_field(elem: Self::BasePrimeField) -> Self {
-        Self(F::from_base_prime_field(elem))
+        Self(F::from_base_prime_field(elem.0))
     }
 
     fn from_random_bytes_with_flags<G: Flags>(bytes: &[u8]) -> Option<(Self, G)> {
@@ -588,7 +674,7 @@ impl<F: ArkWrappedField> ArkWrappedField for ArkField<F> {
     }
 
     fn mul_by_base_prime_field(&self, elem: &Self::BasePrimeField) -> Self {
-        Self(self.0.mul_by_base_prime_field(elem))
+        Self(self.0.mul_by_base_prime_field(&elem.0))
     }
 }
 
@@ -979,7 +1065,7 @@ mod tests {
 
     #[test]
     fn conversions() {
-        // Test From<ArkWrappedField> for ArkField (via new)
+        // Test From<ArkWrappedPrimeField> for ArkField (via new)
         let inner = ArkFp::from(123_u64);
         let wrapped = F::new(inner);
         assert_eq!(wrapped, F::from(123_u64));

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -418,8 +418,7 @@ where
     F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
 {
     type Inner = F;
-    type LiftedInt = BigInt<N>;
-    type Modulus = <F::BasePrimeField as ark_ff::PrimeField>::BigInt;
+    type Integer = BigInt<N>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -437,7 +436,7 @@ where
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::LiftedInt {
+    fn lift_to_integer(self) -> Self::Integer {
         BigInt::new(self.0.into_bigint())
     }
 }

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -680,7 +680,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ConstRing, ensure_type_implements_trait};
+    use crate::{FixedRing, ensure_type_implements_trait};
     use alloc::vec::Vec;
     use ark_ff::{Fp64, Fp256, MontBackend, MontConfig};
     use core::str::FromStr;
@@ -696,7 +696,9 @@ mod tests {
 
     #[test]
     fn ensure_blanket_traits() {
-        ensure_type_implements_trait!(F, ConstRing);
+        ensure_type_implements_trait!(F, FixedRing);
+        // Should be ConstRing, but it's hard to compute MODULUS - 1 for
+        // Self::BigInt
     }
 
     #[test]

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -325,6 +325,7 @@ impl<'a, F: ArkWrappedPrimeField> Product<&'a Self> for ArkField<F> {
 //
 
 impl<F: ArkWrappedPrimeField> From<&ArkField<F>> for ArkField<F> {
+    #[inline(always)]
     fn from(value: &Self) -> Self {
         *value
     }
@@ -334,12 +335,14 @@ macro_rules! impl_from_delegate {
     ($($t:ty),* $(,)?) => {
         $(
             impl<F: ArkWrappedPrimeField> From<$t> for ArkField<F> {
+                #[inline(always)]
                 fn from(value: $t) -> Self {
                     Self(F::from(value))
                 }
             }
 
             impl<F: ArkWrappedPrimeField> From<&$t> for ArkField<F> {
+                #[inline(always)]
                 fn from(value: &$t) -> Self {
                     Self::from(*value)
                 }
@@ -352,25 +355,28 @@ impl_from_delegate!(u8, u16, u32, u64, u128);
 impl_from_delegate!(i8, i16, i32, i64, i128);
 
 impl<F: ArkWrappedPrimeField> From<bool> for ArkField<F> {
+    #[inline(always)]
     fn from(value: bool) -> Self {
         if value { Self::one() } else { Self::zero() }
     }
 }
 
 impl<F: ArkWrappedPrimeField> From<Boolean> for ArkField<F> {
+    #[inline(always)]
     fn from(value: Boolean) -> Self {
         Self::from(*value)
     }
 }
 
 impl<F: ArkWrappedPrimeField> From<&Boolean> for ArkField<F> {
+    #[inline(always)]
     fn from(value: &Boolean) -> Self {
         Self::from(**value)
     }
 }
 
-impl<F: ArkWrappedPrimeField + From<ark_ff::BigInt<N>>, const N: usize> From<BigInt<N>>
-for ArkField<F>
+impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>, const N: usize> From<BigInt<N>>
+    for ArkField<F>
 {
     #[inline(always)]
     fn from(value: BigInt<N>) -> Self {
@@ -378,12 +384,14 @@ for ArkField<F>
     }
 }
 
-impl<F: ArkWrappedPrimeField + From<ark_ff::BigInt<N>>, const N: usize> From<ark_ff::BigInt<N>>
+impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>, const N: usize> From<ark_ff::BigInt<N>>
     for ArkField<F>
 {
     #[inline(always)]
     fn from(value: ark_ff::BigInt<N>) -> Self {
-        Self(F::from(value))
+        // Route through `BigUint` so values >= modulus are reduced rather than
+        // triggering a panic in ark-ff's `Fp::from_bigint`.
+        Self::from(num_bigint::BigUint::from(value))
     }
 }
 
@@ -403,6 +411,7 @@ impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>> From<num_bigint::BigUi
 impl<F: ArkWrappedPrimeField + Into<ark_ff::BigInt<N>>, const N: usize> From<ArkField<F>>
     for ark_ff::BigInt<N>
 {
+    #[inline(always)]
     fn from(value: ArkField<F>) -> Self {
         value.0.into()
     }
@@ -411,6 +420,7 @@ impl<F: ArkWrappedPrimeField + Into<ark_ff::BigInt<N>>, const N: usize> From<Ark
 impl<F: ArkWrappedPrimeField + Into<num_bigint::BigUint>> From<ArkField<F>>
     for num_bigint::BigUint
 {
+    #[inline(always)]
     fn from(value: ArkField<F>) -> Self {
         value.0.into()
     }
@@ -451,7 +461,6 @@ where
         BigInt::new(self.0.into_bigint())
     }
 }
-
 
 impl<F: ArkWrappedPrimeField> HasPrimeFieldConfig for ArkField<F> {
     type Config = ();
@@ -764,6 +773,13 @@ mod tests {
         let o = F::one();
         assert!(!o.is_zero());
         assert_ne!(z, o);
+
+        assert_eq!(F::from(<F as PrimeField>::modulus(&o)), z);
+
+        // Lifting to integer and projecting back yields the original element.
+        for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {
+            assert_eq!(F::from(x.lift_to_integer()), x);
+        }
     }
 
     #[test]

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -436,7 +436,7 @@ where
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::Integer {
+    fn lift_to_integer(&self) -> Self::Integer {
         BigInt::new(self.0.into_bigint())
     }
 }

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -369,9 +369,19 @@ impl<F: ArkWrappedPrimeField> From<&Boolean> for ArkField<F> {
     }
 }
 
+impl<F: ArkWrappedPrimeField + From<ark_ff::BigInt<N>>, const N: usize> From<BigInt<N>>
+for ArkField<F>
+{
+    #[inline(always)]
+    fn from(value: BigInt<N>) -> Self {
+        Self::from(value.into_inner())
+    }
+}
+
 impl<F: ArkWrappedPrimeField + From<ark_ff::BigInt<N>>, const N: usize> From<ark_ff::BigInt<N>>
     for ArkField<F>
 {
+    #[inline(always)]
     fn from(value: ark_ff::BigInt<N>) -> Self {
         Self(F::from(value))
     }
@@ -380,6 +390,7 @@ impl<F: ArkWrappedPrimeField + From<ark_ff::BigInt<N>>, const N: usize> From<ark
 impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>> From<num_bigint::BigUint>
     for ArkField<F>
 {
+    #[inline(always)]
     fn from(value: num_bigint::BigUint) -> Self {
         Self(F::from(value))
     }
@@ -438,6 +449,50 @@ where
     #[inline(always)]
     fn lift_to_integer(&self) -> Self::Integer {
         BigInt::new(self.0.into_bigint())
+    }
+}
+
+
+impl<F: ArkWrappedPrimeField> HasPrimeFieldConfig for ArkField<F> {
+    type Config = ();
+
+    fn cfg(&self) -> &Self::Config {
+        &()
+    }
+}
+
+// TODO: Can be made into ConstPrimeField, but it's hard to compute MODULUS - 1
+impl<F, const N: usize> PrimeField for ArkField<F>
+where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
+{
+    fn is_zero(value: &Self) -> bool {
+        Zero::is_zero(value)
+    }
+
+    fn modulus(&self) -> Self::Integer {
+        BigInt::new(Self::MODULUS)
+    }
+
+    fn modulus_minus_one_div_two(&self) -> Self::Integer {
+        BigInt::new(Self::MODULUS_MINUS_ONE_DIV_TWO)
+    }
+
+    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
+        debug_assert_eq!(*modulus.inner(), Self::MODULUS);
+        Ok(())
+    }
+
+    fn new_unchecked_with_cfg(inner: Self::Inner, _cfg: &Self::Config) -> Self {
+        Self(inner)
+    }
+
+    fn zero_with_cfg(_cfg: &Self::Config) -> Self {
+        Zero::zero()
+    }
+
+    fn one_with_cfg(_cfg: &Self::Config) -> Self {
+        todo!()
     }
 }
 
@@ -696,9 +751,10 @@ mod tests {
 
     #[test]
     fn ensure_blanket_traits() {
-        ensure_type_implements_trait!(F, FixedRing);
         // Should be ConstRing, but it's hard to compute MODULUS - 1 for
         // Self::BigInt
+        ensure_type_implements_trait!(F, FixedRing);
+        ensure_type_implements_trait!(F, PrimeField);
     }
 
     #[test]

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -494,8 +494,7 @@ impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
 
 impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     type Inner = BigInt<N>;
-    type LiftedInt = BigInt<N>;
-    type Modulus = Self::Inner;
+    type Integer = BigInt<N>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -513,14 +512,14 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::LiftedInt {
+    fn lift_to_integer(self) -> Self::Integer {
         BigInt::new(self.0.into_bigint())
     }
 }
 
 /// ConstPrimeField is only implemented for MontConfig and MontBackend
 impl<M: MontConfig<N>, const N: usize> ConstPrimeField for Fp<MontBackend<M, N>, N> {
-    const MODULUS: Self::Modulus = BigInt::new(M::MODULUS);
+    const MODULUS: Self::Integer = BigInt::new(M::MODULUS);
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = BigInt::new(
         <ArkWrappedFp<MontBackend<M, N>, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO,
     );

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -512,7 +512,7 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::Integer {
+    fn lift_to_integer(&self) -> Self::Integer {
         BigInt::new(self.0.into_bigint())
     }
 }

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -524,10 +524,6 @@ impl<M: MontConfig<N>, const N: usize> ConstPrimeField for Fp<MontBackend<M, N>,
         <ArkWrappedFp<MontBackend<M, N>, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO,
     );
 
-    fn new(inner: Self::Inner) -> Self {
-        Self(ArkWrappedFp::new(inner.into_inner()))
-    }
-
     fn new_unchecked(inner: Self::Inner) -> Self {
         Self(ArkWrappedFp::new_unchecked(inner.into_inner()))
     }

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -18,7 +18,6 @@ use core::{
     str::FromStr,
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
-use num_bigint::BigUint;
 use num_traits::{
     CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
 };
@@ -369,6 +368,7 @@ impl<'a, P: FpConfig<N>, const N: usize> Product<&'a Self> for Fp<P, N> {
 //
 
 impl<P: FpConfig<N>, const N: usize> From<&Fp<P, N>> for Fp<P, N> {
+    #[inline(always)]
     fn from(value: &Self) -> Self {
         *value
     }
@@ -378,12 +378,14 @@ macro_rules! impl_from_delegate {
     ($($t:ty),* $(,)?) => {
         $(
             impl<P: FpConfig<N>, const N: usize> From<$t> for Fp<P, N> {
+                #[inline(always)]
                 fn from(value: $t) -> Self {
                     Self(ArkWrappedFp::from(value))
                 }
             }
 
             impl<P: FpConfig<N>, const N: usize> From<&$t> for Fp<P, N> {
+                #[inline(always)]
                 fn from(value: &$t) -> Self {
                     Self::from(*value)
                 }
@@ -396,6 +398,7 @@ impl_from_delegate!(u8, u16, u32, u64, u128);
 impl_from_delegate!(i8, i16, i32, i64, i128);
 
 impl<P: FpConfig<N>, const N: usize> From<bool> for Fp<P, N> {
+    #[inline(always)]
     fn from(value: bool) -> Self {
         if value {
             <Self as ConstOne>::ONE
@@ -406,38 +409,44 @@ impl<P: FpConfig<N>, const N: usize> From<bool> for Fp<P, N> {
 }
 
 impl<P: FpConfig<N>, const N: usize> From<Boolean> for Fp<P, N> {
+    #[inline(always)]
     fn from(value: Boolean) -> Self {
         Self::from(*value)
     }
 }
 
 impl<P: FpConfig<N>, const N: usize> From<&Boolean> for Fp<P, N> {
+    #[inline(always)]
     fn from(value: &Boolean) -> Self {
         Self::from(**value)
     }
 }
 
 impl<P: FpConfig<N>, const N: usize> From<BigInt<N>> for Fp<P, N> {
+    #[inline(always)]
     fn from(value: BigInt<N>) -> Self {
         // Route through `BigUint` so values >= modulus are reduced rather than
         // triggering a panic in ark-ff's `Fp::from_bigint`.
-        Self(ArkWrappedFp::from(BigUint::from(value.into_inner())))
+        Self::from(num_bigint::BigUint::from(value.into_inner()))
     }
 }
 
 impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for BigInt<N> {
+    #[inline(always)]
     fn from(value: Fp<P, N>) -> Self {
         BigInt::new(value.0.into())
     }
 }
 
-impl<P: FpConfig<N>, const N: usize> From<BigUint> for Fp<P, N> {
-    fn from(value: BigUint) -> Self {
+impl<P: FpConfig<N>, const N: usize> From<num_bigint::BigUint> for Fp<P, N> {
+    #[inline(always)]
+    fn from(value: num_bigint::BigUint) -> Self {
         Self(ArkWrappedFp::from(value))
     }
 }
 
-impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for BigUint {
+impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for num_bigint::BigUint {
+    #[inline(always)]
     fn from(value: Fp<P, N>) -> Self {
         value.0.into()
     }

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{IntRing, IntSemiring, Semiring, boolean::Boolean};
 use ark_ff::{
-    AdditiveGroup, BigInt, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
+    AdditiveGroup, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
     SqrtPrecomputation,
     fields::{Field as ArkWrappedField, Fp as ArkWrappedFp, PrimeField as ArkPrimeField},
 };
@@ -23,6 +23,7 @@ use num_traits::{
     CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
 };
 
+use crate::ark_ff_bigint::BigInt;
 #[cfg(feature = "rand")]
 use ark_std::{UniformRand, rand::prelude::*};
 #[cfg(feature = "rand")]
@@ -59,13 +60,15 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
     #[doc(hidden)]
     pub const INV: u64 = T::INV;
     #[doc(hidden)]
-    pub const R: BigInt<N> = T::R;
+    pub const R: BigInt<N> = BigInt::new(T::R);
     #[doc(hidden)]
-    pub const R2: BigInt<N> = T::R2;
+    pub const R2: BigInt<N> = BigInt::new(T::R2);
 
     #[inline(always)]
     pub const fn new_from_bigint(element: BigInt<N>) -> Self {
-        Self(ArkWrappedFp::<MontBackend<T, N>, N>::new(element))
+        Self(ArkWrappedFp::<MontBackend<T, N>, N>::new(
+            element.into_inner(),
+        ))
     }
 }
 
@@ -416,13 +419,13 @@ impl<P: FpConfig<N>, const N: usize> From<&Boolean> for Fp<P, N> {
 
 impl<P: FpConfig<N>, const N: usize> From<BigInt<N>> for Fp<P, N> {
     fn from(value: BigInt<N>) -> Self {
-        Self(ArkWrappedFp::from(value))
+        Self(ArkWrappedFp::from(value.into_inner()))
     }
 }
 
 impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for BigInt<N> {
     fn from(value: Fp<P, N>) -> Self {
-        value.0.into()
+        BigInt::new(value.0.into())
     }
 }
 
@@ -491,36 +494,43 @@ impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
 
 impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     type Inner = BigInt<N>;
+    type LiftedInt = BigInt<N>;
     type Modulus = Self::Inner;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
-        &self.0.0
+        BigInt::new_ref(&self.0.0)
     }
 
     #[inline(always)]
     fn inner_mut(&mut self) -> &mut Self::Inner {
-        &mut self.0.0
+        BigInt::new_ref_mut(&mut self.0.0)
     }
 
     #[inline(always)]
     fn into_inner(self) -> Self::Inner {
-        self.0.0
+        BigInt::new(self.0.0)
+    }
+
+    #[inline(always)]
+    fn lift_to_integer(self) -> Self::LiftedInt {
+        BigInt::new(self.0.into_bigint())
     }
 }
 
 /// ConstPrimeField is only implemented for MontConfig and MontBackend
 impl<M: MontConfig<N>, const N: usize> ConstPrimeField for Fp<MontBackend<M, N>, N> {
-    const MODULUS: Self::Modulus = M::MODULUS;
-    const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner =
-        <ArkWrappedFp<MontBackend<M, N>, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO;
+    const MODULUS: Self::Modulus = BigInt::new(M::MODULUS);
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = BigInt::new(
+        <ArkWrappedFp<MontBackend<M, N>, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO,
+    );
 
     fn new(inner: Self::Inner) -> Self {
-        Self(ArkWrappedFp::new(inner))
+        Self(ArkWrappedFp::new(inner.into_inner()))
     }
 
     fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(ArkWrappedFp::new_unchecked(inner))
+        Self(ArkWrappedFp::new_unchecked(inner.into_inner()))
     }
 }
 
@@ -704,22 +714,22 @@ impl<P: FpConfig<N>, const N: usize> FftField for Fp<P, N> {
 }
 
 impl<P: FpConfig<N>, const N: usize> ArkPrimeField for Fp<P, N> {
-    type BigInt = <ArkWrappedFp<P, N> as ArkPrimeField>::BigInt;
+    type BigInt = BigInt<N>;
 
-    const MODULUS: Self::BigInt = P::MODULUS;
+    const MODULUS: Self::BigInt = BigInt::new(P::MODULUS);
     const MODULUS_BIT_SIZE: u32 = <ArkWrappedFp<P, N> as ArkPrimeField>::MODULUS_BIT_SIZE;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::BigInt =
-        <ArkWrappedFp<P, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO;
-    const TRACE: Self::BigInt = <ArkWrappedFp<P, N> as ArkPrimeField>::TRACE;
+        BigInt::new(<ArkWrappedFp<P, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO);
+    const TRACE: Self::BigInt = BigInt::new(<ArkWrappedFp<P, N> as ArkPrimeField>::TRACE);
     const TRACE_MINUS_ONE_DIV_TWO: Self::BigInt =
-        <ArkWrappedFp<P, N> as ArkPrimeField>::TRACE_MINUS_ONE_DIV_TWO;
+        BigInt::new(<ArkWrappedFp<P, N> as ArkPrimeField>::TRACE_MINUS_ONE_DIV_TWO);
 
     fn from_bigint(repr: Self::BigInt) -> Option<Self> {
-        ArkWrappedFp::<P, N>::from_bigint(repr).map(Self)
+        ArkWrappedFp::<P, N>::from_bigint(repr.into_inner()).map(Self)
     }
 
     fn into_bigint(self) -> Self::BigInt {
-        self.0.into_bigint()
+        self.lift_to_integer()
     }
 }
 

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -419,7 +419,9 @@ impl<P: FpConfig<N>, const N: usize> From<&Boolean> for Fp<P, N> {
 
 impl<P: FpConfig<N>, const N: usize> From<BigInt<N>> for Fp<P, N> {
     fn from(value: BigInt<N>) -> Self {
-        Self(ArkWrappedFp::from(value.into_inner()))
+        // Route through `BigUint` so values >= modulus are reduced rather than
+        // triggering a panic in ark-ff's `Fp::from_bigint`.
+        Self(ArkWrappedFp::from(BigUint::from(value.into_inner())))
     }
 }
 
@@ -780,6 +782,13 @@ mod tests {
         let o = F::one();
         assert!(!o.is_zero());
         assert_ne!(z, o);
+
+        assert_eq!(F::from(<F as PrimeField>::modulus(&o)), z);
+
+        // Lifting to integer and projecting back yields the original element.
+        for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {
+            assert_eq!(F::from(x.lift_to_integer()), x);
+        }
     }
 
     #[test]

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -468,10 +468,6 @@ impl PrimeField for BoxedMontyField {
         Ok(BoxedMontyParams::new(modulus))
     }
 
-    fn new_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::new(inner.into_inner(), cfg.clone()))
-    }
-
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
         Self(BoxedMontyForm::from_montgomery(
             inner.into_inner(),
@@ -553,7 +549,7 @@ mod tests {
         )
         .unwrap();
 
-        let y = F::new_with_cfg(x, &test_config());
+        let y = F::from_with_cfg(x, &test_config());
 
         assert_eq!(y, F::one_with_cfg(&test_config()));
     }

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -547,15 +547,29 @@ mod tests {
 
     #[test]
     fn new_with_cfg_correct() {
+        let cfg = test_config();
+
+        // `modulus + 1` should reduce to one.
         let x = BoxedUint::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
             256,
         )
         .unwrap();
+        assert_eq!(F::from_with_cfg(x, &cfg), F::one_with_cfg(&cfg));
 
-        let y = F::from_with_cfg(x, &test_config());
+        // `modulus` itself should reduce to zero.
+        let modulus = F::one_with_cfg(&cfg).modulus();
+        assert_eq!(F::from_with_cfg(modulus, &cfg), F::zero_with_cfg(&cfg));
 
-        assert_eq!(y, F::one_with_cfg(&test_config()));
+        // Lifting to integer and projecting back yields the original element.
+        for x in [
+            F::zero_with_cfg(&cfg),
+            F::one_with_cfg(&cfg),
+            F::from_with_cfg(2_u64, &cfg),
+            F::from_with_cfg(123456789_u64, &cfg),
+        ] {
+            assert_eq!(F::from_with_cfg(x.lift_to_integer(), &cfg), x);
+        }
     }
 
     #[test]

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -495,7 +495,11 @@ impl zeroize::Zeroize for BoxedMontyField {
     }
 }
 
-#[allow(clippy::arithmetic_side_effects, clippy::cast_lossless)]
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_lossless,
+    clippy::redundant_clone
+)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -409,8 +409,7 @@ impl Ring for BoxedMontyField {}
 
 impl Field for BoxedMontyField {
     type Inner = BoxedUint;
-    type LiftedInt = BoxedUint;
-    type Modulus = Self::Inner;
+    type Integer = BoxedUint;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -434,23 +433,25 @@ impl Field for BoxedMontyField {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::LiftedInt {
+    fn lift_to_integer(self) -> Self::Integer {
         BoxedUint::new(self.0.retrieve())
     }
 }
 
-impl PrimeField for BoxedMontyField {
+impl HasPrimeFieldConfig for BoxedMontyField {
     type Config = BoxedMontyParams;
 
     fn cfg(&self) -> &Self::Config {
         self.0.params()
     }
+}
 
+impl PrimeField for BoxedMontyField {
     fn is_zero(value: &Self) -> bool {
         value.0.is_zero().into()
     }
 
-    fn modulus(&self) -> Self::Modulus {
+    fn modulus(&self) -> Self::Integer {
         BoxedUint::new(self.0.params().modulus().clone().get())
     }
 
@@ -460,7 +461,7 @@ impl PrimeField for BoxedMontyField {
         (value - BoxedUint::one()) / BoxedUint::from(2_u8)
     }
 
-    fn make_cfg(modulus: &Self::Modulus) -> Result<Self::Config, FieldError> {
+    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
         let Some(modulus) = Odd::new(modulus.clone().into_inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
         };

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -433,7 +433,7 @@ impl Field for BoxedMontyField {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::Integer {
+    fn lift_to_integer(&self) -> Self::Integer {
         BoxedUint::new(self.0.retrieve())
     }
 }

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{IntRing, Semiring, boolean::Boolean, crypto_bigint_int::Int};
+use crate::{
+    IntRing, Semiring, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
+    crypto_bigint_int::Int,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -8,11 +11,11 @@ use core::{
     ops::{Add, AddAssign, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 use crypto_bigint::{
-    BoxedUint, NonZero, Odd, Resize,
+    Odd,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, Pow};
+use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, One, Pow};
 
 #[derive(Clone, PartialEq, Eq, InfallibleCheckedOp)]
 #[infallible_checked_unary_op((CheckedNeg, neg))]
@@ -141,7 +144,7 @@ impl Pow<u32> for BoxedMontyField {
     type Output = Self;
 
     fn pow(self, rhs: u32) -> Self::Output {
-        Self(self.0.pow(&BoxedUint::from(rhs)))
+        Self(self.0.pow(BoxedUint::from(rhs).inner()))
     }
 }
 
@@ -283,7 +286,7 @@ macro_rules! impl_from_unsigned {
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let abs: BoxedUint = value.into();
                     let abs = abs.resize(cfg.modulus().bits_precision());
-                    Self(BoxedMontyForm::new(abs, cfg.clone()))
+                    Self(BoxedMontyForm::new(abs.into_inner(), cfg.clone()))
                 }
             }
 
@@ -303,7 +306,7 @@ macro_rules! impl_from_signed {
             impl FromWithConfig<$t> for BoxedMontyField {
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let magnitude = BoxedUint::from(value.abs_diff(0)).resize(cfg.modulus().bits_precision());
-                    let form = BoxedMontyForm::new(magnitude, cfg.clone());
+                    let form = BoxedMontyForm::new(magnitude.into_inner(), cfg.clone());
                     Self(if value.is_negative() { -form } else { form })
                 }
             }
@@ -328,7 +331,7 @@ impl FromWithConfig<bool> for BoxedMontyField {
             BoxedUint::zero()
         };
         let magnitude = magnitude.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(magnitude, cfg.clone()))
+        Self(BoxedMontyForm::new(magnitude.into_inner(), cfg.clone()))
     }
 }
 
@@ -362,7 +365,7 @@ impl<const LIMBS: usize> FromWithConfig<&Int<LIMBS>> for BoxedMontyField {
         let abs: BoxedUint = value.inner().abs().into();
         let abs = abs.resize(cfg.modulus().bits_precision());
 
-        let result = Self(BoxedMontyForm::new(abs, cfg.clone()));
+        let result = Self(BoxedMontyForm::new(abs.into_inner(), cfg.clone()));
 
         if value.is_negative() { -result } else { result }
     }
@@ -377,7 +380,7 @@ impl FromWithConfig<BoxedUint> for BoxedMontyField {
 impl FromWithConfig<&BoxedUint> for BoxedMontyField {
     fn from_with_cfg(value: &BoxedUint, cfg: &Self::Config) -> Self {
         let value = value.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(value, cfg.clone()))
+        Self(BoxedMontyForm::new(value.into_inner(), cfg.clone()))
     }
 }
 
@@ -392,7 +395,7 @@ impl<const LIMBS: usize> FromWithConfig<&crypto_bigint::Uint<LIMBS>> for BoxedMo
     fn from_with_cfg(value: &crypto_bigint::Uint<LIMBS>, cfg: &Self::Config) -> Self {
         let value: BoxedUint = value.into();
         let value = value.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(value, cfg.clone()))
+        Self(BoxedMontyForm::new(value.into_inner(), cfg.clone()))
     }
 }
 
@@ -406,11 +409,12 @@ impl Ring for BoxedMontyField {}
 
 impl Field for BoxedMontyField {
     type Inner = BoxedUint;
+    type LiftedInt = BoxedUint;
     type Modulus = Self::Inner;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
-        self.0.as_montgomery()
+        BoxedUint::new_ref(self.0.as_montgomery())
     }
 
     #[inline(always)]
@@ -426,7 +430,12 @@ impl Field for BoxedMontyField {
 
     #[inline(always)]
     fn into_inner(self) -> Self::Inner {
-        self.0.to_montgomery()
+        BoxedUint::new(self.0.to_montgomery())
+    }
+
+    #[inline(always)]
+    fn lift_to_integer(self) -> Self::LiftedInt {
+        BoxedUint::new(self.0.retrieve())
     }
 }
 
@@ -442,28 +451,31 @@ impl PrimeField for BoxedMontyField {
     }
 
     fn modulus(&self) -> Self::Modulus {
-        self.0.params().modulus().clone().get()
+        BoxedUint::new(self.0.params().modulus().clone().get())
     }
 
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn modulus_minus_one_div_two(&self) -> Self::Inner {
-        let value = self.0.params().modulus().clone().get();
-        (value - BoxedUint::one()) / NonZero::new(BoxedUint::from(2_u8)).unwrap()
+        let value = BoxedUint::new(self.0.params().modulus().clone().get());
+        (value - BoxedUint::one()) / BoxedUint::from(2_u8)
     }
 
     fn make_cfg(modulus: &Self::Modulus) -> Result<Self::Config, FieldError> {
-        let Some(modulus) = Odd::new(modulus.clone()).into_option() else {
+        let Some(modulus) = Odd::new(modulus.clone().into_inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
         };
         Ok(BoxedMontyParams::new(modulus))
     }
 
     fn new_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::new(inner, cfg.clone()))
+        Self(BoxedMontyForm::new(inner.into_inner(), cfg.clone()))
     }
 
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::from_montgomery(inner, cfg.clone()))
+        Self(BoxedMontyForm::from_montgomery(
+            inner.into_inner(),
+            cfg.clone(),
+        ))
     }
 
     fn zero_with_cfg(cfg: &Self::Config) -> Self {
@@ -492,7 +504,6 @@ mod tests {
     use super::*;
     use crate::ensure_type_implements_trait;
     use alloc::vec;
-    use crypto_bigint::BoxedUint;
     use num_traits::Pow;
 
     type F = BoxedMontyField;
@@ -513,7 +524,7 @@ mod tests {
             256,
         )
         .unwrap();
-        let modulus = Odd::new(modulus).expect("modulus should be odd");
+        let modulus = Odd::new(modulus.into_inner()).expect("modulus should be odd");
         BoxedMontyParams::new(modulus)
     }
 
@@ -587,7 +598,7 @@ mod tests {
     #[test]
     fn basic_operations_overflow() {
         let params = test_config();
-        let mod_minus_one = params.modulus().as_ref().clone() - BoxedUint::one();
+        let mod_minus_one = BoxedUint::new(params.modulus().as_ref().clone()) - BoxedUint::one();
         let mod_minus_one = F::from_with_cfg(mod_minus_one, &params);
 
         // Negation
@@ -665,7 +676,7 @@ mod tests {
         let cfg = {
             // Using a 64-bit prime 10064419296686275259
             let modulus = BoxedUint::from_be_hex("8bac0006d9927abb", 64).unwrap();
-            let modulus = Odd::new(modulus).expect("modulus should be odd");
+            let modulus = Odd::new(modulus.into_inner()).expect("modulus should be odd");
             BoxedMontyParams::new(modulus)
         };
         macro_rules! to_field {

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -571,7 +571,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMB
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::Integer {
+    fn lift_to_integer(&self) -> Self::Integer {
         Uint::new(self.0.retrieve())
     }
 }

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -553,8 +553,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Ring for ConstMontyField<Mod, LIMBS
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMBS> {
     type Inner = Uint<LIMBS>;
-    type LiftedInt = Uint<LIMBS>;
-    type Modulus = Self::Inner;
+    type Integer = Uint<LIMBS>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -572,13 +571,13 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMB
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::LiftedInt {
+    fn lift_to_integer(self) -> Self::Integer {
         Uint::new(self.0.retrieve())
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstPrimeField for ConstMontyField<Mod, LIMBS> {
-    const MODULUS: Self::Modulus = *Uint::new_ref(Mod::PARAMS.modulus().as_ref());
+    const MODULUS: Self::Integer = *Uint::new_ref(Mod::PARAMS.modulus().as_ref());
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = {
         let m_minus_one = CBUint::wrapping_sub(Self::MODULUS.inner(), &CBUint::ONE);
         let two = CBUint::<LIMBS>::wrapping_add(&CBUint::ONE, &CBUint::ONE);

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -588,11 +588,6 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstPrimeField for ConstMontyField
     };
 
     #[inline(always)]
-    fn new(inner: Self::Inner) -> Self {
-        Self(ConstMontyForm::new(inner.inner()))
-    }
-
-    #[inline(always)]
     fn new_unchecked(inner: Self::Inner) -> Self {
         Self(ConstMontyForm::from_montgomery(inner.into_inner()))
     }

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -553,6 +553,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Ring for ConstMontyField<Mod, LIMBS
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMBS> {
     type Inner = Uint<LIMBS>;
+    type LiftedInt = Uint<LIMBS>;
     type Modulus = Self::Inner;
 
     #[inline(always)]
@@ -568,6 +569,11 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMB
     #[inline(always)]
     fn into_inner(self) -> Self::Inner {
         Uint::new(self.0.to_montgomery())
+    }
+
+    #[inline(always)]
+    fn lift_to_integer(self) -> Self::LiftedInt {
+        Uint::new(self.0.retrieve())
     }
 }
 

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -760,13 +760,18 @@ mod tests {
 
     #[test]
     fn new_with_cfg_correct() {
+        // `modulus + 1` should reduce to one.
         let x = Uint::new(U256::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
         ));
+        assert_eq!(F::new(x), F::one());
 
-        let y = F::new(x);
+        assert_eq!(F::from(<F as PrimeField>::modulus(&F::one())), F::zero());
 
-        assert_eq!(y, F::one());
+        // Lifting to integer and projecting back yields the original element.
+        for x in [F::zero(), F::one(), F::from(2_u64), F::from(123456789_u64)] {
+            assert_eq!(F::from(x.lift_to_integer()), x);
+        }
     }
 
     #[test]

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -23,6 +23,8 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, Pow
 pub struct MontyField<const LIMBS: usize>(MontyForm<LIMBS>);
 
 impl<const LIMBS: usize> MontyField<LIMBS> {
+    pub const LIMBS: usize = LIMBS;
+
     /// Creates a new `MontyField` from a `MontyForm`.
     #[inline(always)]
     pub const fn new(form: MontyForm<LIMBS>) -> Self {
@@ -543,10 +545,6 @@ impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
         Ok(MontyParams::new(modulus))
     }
 
-    fn new_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(MontyForm::new(inner.inner(), *cfg))
-    }
-
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
         Self(MontyForm::from_montgomery(inner.into_inner(), *cfg))
     }
@@ -628,10 +626,11 @@ mod tests {
 
     #[test]
     fn new_with_cfg_correct() {
-        let x =
-            Uint::from_be_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30");
+        let x = Uint::<{ F256::LIMBS }>::from_be_hex(
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+        );
 
-        let y = F::new_with_cfg(x, &test_config());
+        let y = F::from_with_cfg(x, &test_config());
 
         assert_eq!(y, F::one_with_cfg(&test_config()));
     }

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -507,7 +507,7 @@ impl<const LIMBS: usize> Field for MontyField<LIMBS> {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::Integer {
+    fn lift_to_integer(&self) -> Self::Integer {
         Uint::new(self.0.retrieve())
     }
 }

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -487,6 +487,7 @@ impl<const LIMBS: usize> Ring for MontyField<LIMBS> {}
 
 impl<const LIMBS: usize> Field for MontyField<LIMBS> {
     type Inner = Uint<LIMBS>;
+    type LiftedInt = Uint<LIMBS>;
     type Modulus = Self::Inner;
 
     #[inline(always)]
@@ -502,6 +503,11 @@ impl<const LIMBS: usize> Field for MontyField<LIMBS> {
     #[inline(always)]
     fn into_inner(self) -> Self::Inner {
         Uint::new(self.0.to_montgomery())
+    }
+
+    #[inline(always)]
+    fn lift_to_integer(self) -> Self::LiftedInt {
+        Uint::new(self.0.retrieve())
     }
 }
 

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -487,8 +487,7 @@ impl<const LIMBS: usize> Ring for MontyField<LIMBS> {}
 
 impl<const LIMBS: usize> Field for MontyField<LIMBS> {
     type Inner = Uint<LIMBS>;
-    type LiftedInt = Uint<LIMBS>;
-    type Modulus = Self::Inner;
+    type Integer = Uint<LIMBS>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -506,23 +505,25 @@ impl<const LIMBS: usize> Field for MontyField<LIMBS> {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::LiftedInt {
+    fn lift_to_integer(self) -> Self::Integer {
         Uint::new(self.0.retrieve())
     }
 }
 
-impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
+impl<const LIMBS: usize> HasPrimeFieldConfig for MontyField<LIMBS> {
     type Config = MontyParams<LIMBS>;
 
     fn cfg(&self) -> &Self::Config {
         self.0.params()
     }
+}
 
+impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
     fn is_zero(value: &Self) -> bool {
         value.0.as_montgomery().is_zero()
     }
 
-    fn modulus(&self) -> Self::Modulus {
+    fn modulus(&self) -> Self::Integer {
         Uint::new(self.0.params().modulus().get())
     }
 
@@ -535,7 +536,7 @@ impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
         )
     }
 
-    fn make_cfg(modulus: &Self::Modulus) -> Result<Self::Config, FieldError> {
+    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
         let Some(modulus) = Odd::new(*modulus.inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
         };

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -630,13 +630,27 @@ mod tests {
 
     #[test]
     fn new_with_cfg_correct() {
+        let cfg = test_config();
+
+        // `modulus + 1` should reduce to one.
         let x = Uint::<{ F256::LIMBS }>::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
         );
+        assert_eq!(F::from_with_cfg(x, &cfg), F::one_with_cfg(&cfg));
 
-        let y = F::from_with_cfg(x, &test_config());
+        // `modulus` itself should reduce to zero.
+        let modulus = F::one_with_cfg(&cfg).modulus();
+        assert_eq!(F::from_with_cfg(modulus, &cfg), F::zero_with_cfg(&cfg));
 
-        assert_eq!(y, F::one_with_cfg(&test_config()));
+        // Lifting to integer and projecting back yields the original element.
+        for x in [
+            F::zero_with_cfg(&cfg),
+            F::one_with_cfg(&cfg),
+            F::from_with_cfg(2_u64, &cfg),
+            F::from_with_cfg(123456789_u64, &cfg),
+        ] {
+            assert_eq!(F::from_with_cfg(x.lift_to_integer(), &cfg), x);
+        }
     }
 
     fn from_u64(value: u64) -> F {

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -600,7 +600,11 @@ pub type F8192 = MontyField<{ 128 * WORD_FACTOR }>;
 pub type F16384 = MontyField<{ 256 * WORD_FACTOR }>;
 pub type F32768 = MontyField<{ 512 * WORD_FACTOR }>;
 
-#[allow(clippy::arithmetic_side_effects, clippy::cast_lossless)]
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_lossless,
+    clippy::redundant_clone
+)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -400,7 +400,7 @@ impl Field for F2 {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::Integer {
+    fn lift_to_integer(&self) -> Self::Integer {
         u8::from(self.0)
     }
 }

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -410,11 +410,6 @@ impl ConstPrimeField for F2 {
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = false;
 
     #[inline(always)]
-    fn new(inner: Self::Inner) -> Self {
-        Self(inner)
-    }
-
-    #[inline(always)]
     fn new_unchecked(inner: Self::Inner) -> Self {
         Self(inner)
     }

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -407,7 +407,7 @@ impl Field for F2 {
 
 impl ConstPrimeField for F2 {
     const MODULUS: Self::Integer = 2;
-    const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = false;
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = 0;
 
     #[inline(always)]
     fn new_unchecked(inner: Self::Inner) -> Self {
@@ -705,7 +705,7 @@ mod tests {
     #[test]
     fn const_prime_field() {
         assert_eq!(<F2 as ConstPrimeField>::MODULUS, 2_u8);
-        assert_eq!(<F2 as ConstPrimeField>::MODULUS_MINUS_ONE_DIV_TWO, false);
+        assert_eq!(<F2 as ConstPrimeField>::MODULUS_MINUS_ONE_DIV_TWO, 0_u8);
 
         assert_eq!(F2::new(true), V1);
         assert_eq!(F2::new(false), V0);
@@ -716,7 +716,7 @@ mod tests {
     #[test]
     fn prime_field_methods() {
         assert_eq!(V1.modulus(), 2_u8);
-        assert_eq!(V1.modulus_minus_one_div_two(), false);
+        assert_eq!(V1.modulus_minus_one_div_two(), 0_u8);
         assert_eq!(F2::make_cfg(&2_u8), Ok(()));
         assert!(F2::make_cfg(&0_u8).is_err());
         assert!(F2::make_cfg(&3_u8).is_err());

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -476,6 +476,13 @@ mod tests {
         assert!(!V1.is_zero());
         assert!(!PrimeField::is_zero(&V1));
         assert_ne!(V0, V1);
+
+        assert_eq!(F2::from(V1.modulus()), V0);
+
+        // Lifting to integer and projecting back yields the original element.
+        for x in [V0, V1] {
+            assert_eq!(F2::from(x.lift_to_integer()), x);
+        }
     }
 
     #[test]

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -382,6 +382,7 @@ impl Ring for F2 {}
 
 impl Field for F2 {
     type Inner = bool;
+    type LiftedInt = u8;
     type Modulus = u8;
 
     #[inline(always)]
@@ -397,6 +398,11 @@ impl Field for F2 {
     #[inline(always)]
     fn into_inner(self) -> Self::Inner {
         self.0
+    }
+
+    #[inline(always)]
+    fn lift_to_integer(self) -> Self::LiftedInt {
+        u8::from(self.0)
     }
 }
 

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -382,8 +382,7 @@ impl Ring for F2 {}
 
 impl Field for F2 {
     type Inner = bool;
-    type LiftedInt = u8;
-    type Modulus = u8;
+    type Integer = u8;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -401,13 +400,13 @@ impl Field for F2 {
     }
 
     #[inline(always)]
-    fn lift_to_integer(self) -> Self::LiftedInt {
+    fn lift_to_integer(self) -> Self::Integer {
         u8::from(self.0)
     }
 }
 
 impl ConstPrimeField for F2 {
-    const MODULUS: Self::Modulus = 2;
+    const MODULUS: Self::Integer = 2;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = false;
 
     #[inline(always)]

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_int;
 
-use crate::{ConstIntSemiring, FixedSemiring, IntSemiring, IntSemiringWithShifts, Semiring};
+use crate::{
+    ConstIntSemiring, ConstSemiring, FixedSemiring, IntSemiring, IntSemiringWithShifts, Semiring,
+};
 use core::ops::{Neg, Rem, RemAssign};
 use num_traits::{CheckedNeg, CheckedRem};
 
@@ -13,8 +15,9 @@ pub trait Ring: Semiring + Neg<Output = Self> + CheckedNeg {}
 pub trait FixedRing: Ring + FixedSemiring {}
 impl<T> FixedRing for T where T: Ring + FixedSemiring {}
 
-pub trait ConstRing: FixedRing + FixedSemiring {}
-impl<T> ConstRing for T where T: FixedRing + FixedSemiring {}
+/// Ring with a bunch of values known at compile time.
+pub trait ConstRing: FixedRing + ConstSemiring {}
+impl<T> ConstRing for T where T: FixedRing + ConstSemiring {}
 
 /// Ring of integers, usually denoted as `Z`.
 pub trait IntRing: Ring + IntSemiring {

--- a/src/semiring.rs
+++ b/src/semiring.rs
@@ -50,9 +50,17 @@ pub trait Semiring:
     + for<'a> MulAssign<&'a Self>
     {}
 
-/// Ring whose zero and one elements can be constructed from the type alone.
+/// Semiring whose zero and one elements can be constructed from the type alone.
 pub trait FixedSemiring:
-    Semiring + Sum + Product + for<'a> Sum<&'a Self> + for<'a> Product<&'a Self> + Default + Zero + One
+    Semiring
+    + Sum
+    + Product
+    + for<'a> Sum<&'a Self>
+    + for<'a> Product<&'a Self>
+    + Default
+    + Zero
+    + One
+    + From<bool>
 {
 }
 impl<T> FixedSemiring for T where
@@ -64,10 +72,12 @@ impl<T> FixedSemiring for T where
         + Default
         + Zero
         + One
+        + From<bool>
 {
 }
 
-pub trait ConstSemiring: FixedSemiring + ConstZero + ConstOne + From<bool> {
+/// Semiring with a bunch of values known at compile time.
+pub trait ConstSemiring: FixedSemiring + ConstZero + ConstOne {
     /// Minimum value of the semiring. For fields, this is the smallest
     /// representable value.
     const MIN: Self;

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -58,6 +58,12 @@ impl<const N: usize> BigInt<N> {
         &self.0
     }
 
+    /// Get the mutable reference to the wrapped value
+    #[inline(always)]
+    pub const fn inner_mut(&mut self) -> &mut ArkBigInt<N> {
+        &mut self.0
+    }
+
     /// Get the wrapped value, consuming self
     #[inline(always)]
     pub const fn into_inner(self) -> ArkBigInt<N> {

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -624,7 +624,8 @@ impl crypto_bigint::subtle::ConstantTimeLess for BoxedUint {
 #[allow(
     clippy::arithmetic_side_effects,
     clippy::cast_lossless,
-    clippy::identity_op
+    clippy::identity_op,
+    clippy::redundant_clone
 )]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR introduces a bunch of backward-incompatible changes to the API.
* `Field::Modulus` replaced by `Field::Integer`.
* Added `lift_to_integer(&self) -> Self::Integer` to `Field` that allows to naturally lift a represented element into `[0, p)` by "forgetting the modulus".

Additional changes:
* `Config` moved from `PrimeField` to a new trait `HasPrimeFieldConfig`. It's used to decouple `FromWithConfig` from `PrimeField`.
* `PrimeField` now requires `FromWithConfig<Self::Integer>` to project a lifted integer back to the field.
* Fixed a mistake where `ConstRing` inherited from `FixedSemiring` instead of `ConstSemiring`.
* `From<bool>` requirement moved from `ConstSemiring` to a more relaxed `FixedSemiring`.