### PR TITLE
PrimeField now requires From<&Integer> in addition to From<Integer>

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -76,7 +76,12 @@ pub trait HasPrimeFieldConfig {
 /// the same, otherwise operations should panic in debug mode.
 ///
 /// Constant prime fields are considered a special case of dynamic prime fields.
-pub trait PrimeField: Field + HasPrimeFieldConfig + FromWithConfig<Self::Integer> {
+pub trait PrimeField:
+    Field
+    + HasPrimeFieldConfig
+    + FromWithConfig<Self::Integer>
+    + for<'a> FromWithConfig<&'a Self::Integer>
+{
     fn modulus(cfg: &Self::Config) -> Self::Integer;
 
     fn modulus_minus_one_div_two(cfg: &Self::Config) -> Self::Integer;
@@ -107,6 +112,7 @@ pub trait ConstPrimeField:
     + From<u128>
     + From<Self::Inner>
     + From<Self::Integer>
+    + for<'a> From<&'a Self::Integer>
 {
     const MODULUS: Self::Integer;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -369,6 +369,15 @@ impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>, const N: usize> From<B
     }
 }
 
+impl<'a, F: ArkWrappedPrimeField + From<num_bigint::BigUint>, const N: usize> From<&'a BigInt<N>>
+    for ArkField<F>
+{
+    #[inline(always)]
+    fn from(value: &'a BigInt<N>) -> Self {
+        Self::from(*value)
+    }
+}
+
 impl<F: ArkWrappedPrimeField + From<num_bigint::BigUint>, const N: usize> From<ark_ff::BigInt<N>>
     for ArkField<F>
 {

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -431,6 +431,13 @@ impl<P: FpConfig<N>, const N: usize> From<BigInt<N>> for Fp<P, N> {
     }
 }
 
+impl<'a, P: FpConfig<N>, const N: usize> From<&'a BigInt<N>> for Fp<P, N> {
+    #[inline(always)]
+    fn from(value: &'a BigInt<N>) -> Self {
+        Self::from(*value)
+    }
+}
+
 impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for BigInt<N> {
     #[inline(always)]
     fn from(value: Fp<P, N>) -> Self {


### PR DESCRIPTION
Delegates to `From<Integer>` for `ark-ff` wrappers