### PR TITLE
Update crypto-bigint and rand dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pastey = "0"
 thiserror = "2"
 
 # Wrapped crates
-crypto-bigint = { version = ">= 0.7.0-rc.0, <= 0.7.0-rc.9", default-features = false, optional = true }
+crypto-bigint = { version = ">= 0.7.1, < 0.8", default-features = false, optional = true }
 ark-std = { version = "0.5", default-features = false, optional = true }
 ark-ff = { version = "0.5", default-features = false, optional = true }
 ark-serialize = { version = "0.5", default-features = false, optional = true }
@@ -83,7 +83,7 @@ crypto-primitives = { path = "." }
 crypto-primitives-proc-macros = { path = "proc-macros" }
 num-traits = { version = "0.2", default-features = false }
 proptest = { version = "1", default-features = false, features = ["alloc"] }
-rand = { version = "~0.9", default-features = false }
+rand = { version = "0.10", default-features = false }
 criterion = "0.7.0"
 
 [workspace.lints.rust]

--- a/benches/monty_field_benches.rs
+++ b/benches/monty_field_benches.rs
@@ -4,19 +4,19 @@
 mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use crypto_bigint::{Odd, modular::MontyParams};
+use crypto_bigint::{Odd, modular::FixedMontyParams};
 use crypto_primitives::crypto_bigint_monty::MontyField;
 
 use crate::field_ops_bench_common::field_benchmarks;
 
 const LIMBS: usize = 4;
 
-fn bench_config() -> MontyParams<LIMBS> {
+fn bench_config() -> FixedMontyParams<LIMBS> {
     let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
         "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
     );
     let modulus = Odd::new(modulus).expect("modulus should be odd");
-    MontyParams::new(modulus)
+    FixedMontyParams::new(modulus)
 }
 
 fn monty_field_benches(c: &mut Criterion) {

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -62,7 +62,7 @@ impl PartialOrd for BoxedMontyField {
 
 impl Hash for BoxedMontyField {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_montgomery().hash(state)
+        self.0.as_montgomery().as_limbs().hash(state)
     }
 }
 
@@ -286,7 +286,7 @@ macro_rules! impl_from_unsigned {
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let abs: BoxedUint = value.into();
                     let abs = abs.resize(cfg.modulus().bits_precision());
-                    Self(BoxedMontyForm::new(abs.into_inner(), cfg.clone()))
+                    Self(BoxedMontyForm::new(abs.into_inner(), cfg))
                 }
             }
 
@@ -306,7 +306,7 @@ macro_rules! impl_from_signed {
             impl FromWithConfig<$t> for BoxedMontyField {
                 fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
                     let magnitude = BoxedUint::from(value.abs_diff(0)).resize(cfg.modulus().bits_precision());
-                    let form = BoxedMontyForm::new(magnitude.into_inner(), cfg.clone());
+                    let form = BoxedMontyForm::new(magnitude.into_inner(), cfg);
                     Self(if value.is_negative() { -form } else { form })
                 }
             }
@@ -331,7 +331,7 @@ impl FromWithConfig<bool> for BoxedMontyField {
             BoxedUint::zero()
         };
         let magnitude = magnitude.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(magnitude.into_inner(), cfg.clone()))
+        Self(BoxedMontyForm::new(magnitude.into_inner(), cfg))
     }
 }
 
@@ -365,7 +365,7 @@ impl<const LIMBS: usize> FromWithConfig<&Int<LIMBS>> for BoxedMontyField {
         let abs: BoxedUint = value.inner().abs().into();
         let abs = abs.resize(cfg.modulus().bits_precision());
 
-        let result = Self(BoxedMontyForm::new(abs.into_inner(), cfg.clone()));
+        let result = Self(BoxedMontyForm::new(abs.into_inner(), cfg));
 
         if value.is_negative() { -result } else { result }
     }
@@ -380,7 +380,7 @@ impl FromWithConfig<BoxedUint> for BoxedMontyField {
 impl FromWithConfig<&BoxedUint> for BoxedMontyField {
     fn from_with_cfg(value: &BoxedUint, cfg: &Self::Config) -> Self {
         let value = value.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(value.into_inner(), cfg.clone()))
+        Self(BoxedMontyForm::new(value.into_inner(), cfg))
     }
 }
 
@@ -395,7 +395,7 @@ impl<const LIMBS: usize> FromWithConfig<&crypto_bigint::Uint<LIMBS>> for BoxedMo
     fn from_with_cfg(value: &crypto_bigint::Uint<LIMBS>, cfg: &Self::Config) -> Self {
         let value: BoxedUint = value.into();
         let value = value.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(value.into_inner(), cfg.clone()))
+        Self(BoxedMontyForm::new(value.into_inner(), cfg))
     }
 }
 
@@ -465,10 +465,7 @@ impl PrimeField for BoxedMontyField {
     }
 
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::from_montgomery(
-            inner.into_inner(),
-            cfg.clone(),
-        ))
+        Self(BoxedMontyForm::from_montgomery(inner.into_inner(), cfg))
     }
 
     fn is_zero(value: &Self) -> bool {
@@ -476,11 +473,11 @@ impl PrimeField for BoxedMontyField {
     }
 
     fn zero_with_cfg(cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::zero(cfg.clone()))
+        Self(BoxedMontyForm::zero(cfg))
     }
 
     fn one_with_cfg(cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::one(cfg.clone()))
+        Self(BoxedMontyForm::one(cfg))
     }
 }
 

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -11,7 +11,6 @@ use core::{
 use crypto_bigint::{
     Limb, NonZeroUint, Uint as CBUint,
     modular::{ConstMontyForm, ConstMontyParams as Params, Retrieve},
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
 use num_traits::{
@@ -19,7 +18,7 @@ use num_traits::{
 };
 
 #[cfg(feature = "rand")]
-use rand::{distr::StandardUniform, prelude::*, rand_core::TryRngCore};
+use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
 #[derive(Clone, Copy, PartialEq, Eq, InfallibleCheckedOp)]
 #[infallible_checked_unary_op((CheckedNeg, neg))]
@@ -160,7 +159,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Zero for ConstMontyField<Mod, LIMBS
 
     #[inline(always)]
     fn is_zero(&self) -> bool {
-        self == &Self::ZERO
+        self.0.is_zero()
     }
 }
 
@@ -602,14 +601,14 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Distribution<ConstMontyField<Mod, L
     for StandardUniform
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ConstMontyField<Mod, LIMBS> {
-        crypto_bigint::Random::random(rng)
+        crypto_bigint::Random::random_from_rng(rng)
     }
 }
 
 #[cfg(feature = "rand")]
 impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::Random for ConstMontyField<Mod, LIMBS> {
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        ConstMontyForm::try_random(rng).map(Self)
+    fn try_random_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        ConstMontyForm::try_random_from_rng(rng).map(Self)
     }
 }
 
@@ -662,18 +661,18 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> zeroize::Zeroize for ConstMontyFiel
 // Traits from crypto_bigint
 //
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstantTimeEq for ConstMontyField<Mod, LIMBS> {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
+impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::CtEq for ConstMontyField<Mod, LIMBS> {
+    fn ct_eq(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtEq::ct_eq(&self.0, &other.0)
     }
 }
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> ConditionallySelectable
+impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::CtSelect
     for ConstMontyField<Mod, LIMBS>
 {
     #[inline(always)]
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(ConstMontyForm::conditional_select(&a.0, &b.0, choice))
+    fn ct_select(&self, other: &Self, choice: crypto_bigint::Choice) -> Self {
+        crypto_bigint::CtSelect::ct_select(&self.0, &other.0, choice).into()
     }
 }
 
@@ -1112,11 +1111,13 @@ mod tests {
 
     #[test]
     fn const_time_eq_and_order() {
+        use crypto_bigint::CtEq;
+
         let a: F = 10_u64.into();
         let b: F = 10_u64.into();
         let c: F = 11_u64.into();
-        assert_eq!(a.ct_eq(&b).unwrap_u8(), 1);
-        assert_eq!(a.ct_eq(&c).unwrap_u8(), 0);
+        assert_eq!(a.ct_eq(&c).to_u8(), 0);
+        assert_eq!(a.ct_eq(&b).to_u8(), 1);
         assert!(a.partial_cmp(&c).is_some());
     }
 
@@ -1317,16 +1318,16 @@ mod tests {
 
     #[test]
     fn constant_time_selectable() {
-        use crypto_bigint::subtle::Choice;
+        use crypto_bigint::{Choice, CtSelect};
 
         let a: F = 10_u64.into();
         let b: F = 20_u64.into();
 
-        // Test ConditionallySelectable
-        let selected_a = F::conditional_select(&a, &b, Choice::from(0));
+        // Test CtSelect
+        let selected_a = a.ct_select(&b, Choice::from(0));
         assert_eq!(selected_a, a);
 
-        let selected_b = F::conditional_select(&a, &b, Choice::from(1));
+        let selected_b = a.ct_select(&b, Choice::from(1));
         assert_eq!(selected_b, b);
     }
 
@@ -1391,8 +1392,8 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(1);
 
         // Test crypto_bigint::Random trait
-        let random1: F = crypto_bigint::Random::random(&mut rng);
-        let random2: F = crypto_bigint::Random::random(&mut rng);
+        let random1: F = <F as crypto_bigint::Random>::random_from_rng(&mut rng);
+        let random2: F = <F as crypto_bigint::Random>::random_from_rng(&mut rng);
 
         // Random values should be different
         assert_ne!(random1, random2);

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -11,7 +11,7 @@ use core::{
 };
 use crypto_bigint::{
     NonZero, Odd, One,
-    modular::{MontyForm, MontyParams},
+    modular::{FixedMontyForm, FixedMontyParams},
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, Pow};
@@ -20,20 +20,20 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, Pow
 #[infallible_checked_unary_op((CheckedNeg, neg))]
 #[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
 #[repr(transparent)]
-pub struct MontyField<const LIMBS: usize>(MontyForm<LIMBS>);
+pub struct MontyField<const LIMBS: usize>(FixedMontyForm<LIMBS>);
 
 impl<const LIMBS: usize> MontyField<LIMBS> {
     pub const LIMBS: usize = LIMBS;
 
     /// Creates a new `MontyField` from a `MontyForm`.
     #[inline(always)]
-    pub const fn new(form: MontyForm<LIMBS>) -> Self {
+    pub const fn new(form: FixedMontyForm<LIMBS>) -> Self {
         Self(form)
     }
 
     #[inline(always)]
-    pub const fn new_unchecked(inner: Uint<LIMBS>, config: &MontyParams<LIMBS>) -> Self {
-        Self(MontyForm::from_montgomery(inner.into_inner(), *config))
+    pub const fn new_unchecked(inner: Uint<LIMBS>, config: &FixedMontyParams<LIMBS>) -> Self {
+        Self(FixedMontyForm::from_montgomery(inner.into_inner(), config))
     }
 
     #[inline(always)]
@@ -63,8 +63,11 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
     }
 
     /// Create a `MontyField` from a value in Montgomery form.
-    pub const fn from_montgomery(integer: Uint<LIMBS>, config: &MontyParams<LIMBS>) -> Self {
-        Self(MontyForm::from_montgomery(integer.into_inner(), *config))
+    pub const fn from_montgomery(integer: Uint<LIMBS>, config: &FixedMontyParams<LIMBS>) -> Self {
+        Self(FixedMontyForm::from_montgomery(
+            integer.into_inner(),
+            config,
+        ))
     }
 
     /// Extract the value from the `MontyForm` in Montgomery form.
@@ -293,7 +296,7 @@ impl<const LIMBS: usize> Sum for MontyField<LIMBS> {
         let Some(MontyField(first)) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for MontyField");
         };
-        Self(iter.fold(first, |acc, x| MontyForm::add(&acc, &x.0)))
+        Self(iter.fold(first, |acc, x| FixedMontyForm::add(&acc, &x.0)))
     }
 }
 
@@ -302,7 +305,7 @@ impl<'a, const LIMBS: usize> Sum<&'a Self> for MontyField<LIMBS> {
         let Some(MontyField(first)) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for MontyField");
         };
-        Self(iter.fold(*first, |acc, x| MontyForm::add(&acc, &x.0)))
+        Self(iter.fold(*first, |acc, x| FixedMontyForm::add(&acc, &x.0)))
     }
 }
 
@@ -330,14 +333,14 @@ impl<'a, const LIMBS: usize> Product<&'a Self> for MontyField<LIMBS> {
 // Conversions
 //
 
-impl<const LIMBS: usize> From<MontyForm<LIMBS>> for MontyField<LIMBS> {
+impl<const LIMBS: usize> From<FixedMontyForm<LIMBS>> for MontyField<LIMBS> {
     #[inline(always)]
-    fn from(value: MontyForm<LIMBS>) -> Self {
+    fn from(value: FixedMontyForm<LIMBS>) -> Self {
         Self(value)
     }
 }
 
-impl<const LIMBS: usize> From<MontyField<LIMBS>> for MontyForm<LIMBS> {
+impl<const LIMBS: usize> From<MontyField<LIMBS>> for FixedMontyForm<LIMBS> {
     #[inline(always)]
     fn from(value: MontyField<LIMBS>) -> Self {
         value.0
@@ -361,7 +364,7 @@ macro_rules! impl_from_unsigned {
                         cfg.r2(),
                         cfg.modulus(),
                     );
-                    MontyField(MontyForm::from_montgomery(monty_mul, *cfg))
+                    MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg))
                 }
             }
 
@@ -386,7 +389,7 @@ macro_rules! impl_from_signed {
                         cfg.r2(),
                         cfg.modulus(),
                     );
-                    let result = MontyField(MontyForm::from_montgomery(monty_mul, *cfg));
+                    let result = MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg));
                     if value.is_negative() { -result } else { result }
                 }
             }
@@ -410,7 +413,7 @@ impl<const LIMBS: usize> FromWithConfig<bool> for MontyField<LIMBS> {
         } else {
             Zero::zero()
         };
-        Self(MontyForm::new(&value, *cfg))
+        Self(FixedMontyForm::new(&value, cfg))
     }
 }
 
@@ -448,7 +451,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Int<LIMBS2>> for M
         let abs = abs.resize();
 
         let monty_mul = crypto_bigint_helpers::mul::monty_mul(&abs, cfg.r2(), cfg.modulus());
-        let result = MontyField(MontyForm::from_montgomery(monty_mul, *cfg));
+        let result = MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg));
 
         if value.is_negative() { -result } else { result }
     }
@@ -475,7 +478,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Uint<LIMBS2>> for 
         };
 
         let monty_mul = crypto_bigint_helpers::mul::monty_mul(&value, cfg.r2(), cfg.modulus());
-        MontyField(MontyForm::from_montgomery(monty_mul, *cfg))
+        MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg))
     }
 }
 
@@ -513,7 +516,7 @@ impl<const LIMBS: usize> Field for MontyField<LIMBS> {
 }
 
 impl<const LIMBS: usize> HasPrimeFieldConfig for MontyField<LIMBS> {
-    type Config = MontyParams<LIMBS>;
+    type Config = FixedMontyParams<LIMBS>;
 
     fn cfg(&self) -> &Self::Config {
         self.0.params()
@@ -538,23 +541,23 @@ impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
         let Some(modulus) = Odd::new(*modulus.inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
         };
-        Ok(MontyParams::new(modulus))
+        Ok(FixedMontyParams::new(modulus))
     }
 
     fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(MontyForm::from_montgomery(inner.into_inner(), *cfg))
+        Self(FixedMontyForm::from_montgomery(inner.into_inner(), cfg))
     }
 
     fn is_zero(value: &Self) -> bool {
-        value.0.as_montgomery().is_zero()
+        value.0.as_montgomery().is_zero_vartime()
     }
 
     fn zero_with_cfg(cfg: &Self::Config) -> Self {
-        Self(MontyForm::zero(*cfg))
+        Self(FixedMontyForm::zero(cfg))
     }
 
     fn one_with_cfg(cfg: &Self::Config) -> Self {
-        Self(MontyForm::one(*cfg))
+        Self(FixedMontyForm::one(cfg))
     }
 }
 
@@ -619,13 +622,13 @@ mod tests {
     //
     // Test helpers
     //
-    fn test_config() -> MontyParams<LIMBS> {
+    fn test_config() -> FixedMontyParams<LIMBS> {
         // Using a 256-bit prime 2^256 - 2^32 - 977 (secp256k1 field prime)
         let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
         );
         let modulus = Odd::new(modulus).expect("modulus should be odd");
-        MontyParams::new(modulus)
+        FixedMontyParams::new(modulus)
     }
 
     #[test]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,34 +1,32 @@
 //! Contains helper utility functions and macros not visible to the outside
 //! world.
 
+/// Implement exponentiation using repeated squaring
 #[macro_export]
-macro_rules! impl_pow_via_repeated_squaring {
-    () => {
-        fn pow(self, rhs: u32) -> Self::Output {
-            // Implement exponentiation using repeated squaring
-            if rhs == 0 {
-                return Self::one();
-            }
-
-            let mut base = self;
-            let mut result = Self::one();
-            let mut exp = rhs;
-
-            while exp > 0 {
-                if exp & 1 == 1 {
-                    result = result
-                        .checked_mul(&base)
-                        .expect("overflow in exponentiation");
-                }
-                exp >>= 1;
-                if exp > 0 {
-                    base = base.checked_mul(&base).expect("overflow in exponentiation");
-                }
-            }
-
-            result
+macro_rules! pow_via_repeated_squaring {
+    ($self:expr, $rhs:expr, $one_expr:expr) => {{
+        if $rhs == 0 {
+            return $one_expr;
         }
-    };
+
+        let mut base = $self;
+        let mut result = $one_expr;
+        let mut exp = $rhs;
+
+        while exp > 0 {
+            if exp & 1 == 1 {
+                result = result
+                    .checked_mul(&base)
+                    .expect("overflow in exponentiation");
+            }
+            exp >>= 1;
+            if exp > 0 {
+                base = base.checked_mul(&base).expect("overflow in exponentiation");
+            }
+        }
+
+        result
+    }};
 }
 
 /// Will fail compilation if trait is not implemented for the type.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,13 +4,13 @@
 /// Implement exponentiation using repeated squaring
 #[macro_export]
 macro_rules! pow_via_repeated_squaring {
-    ($self:expr, $rhs:expr, $one_expr:expr) => {{
+    ($self:expr, $rhs:expr, $one:expr) => {{
         if $rhs == 0 {
-            return $one_expr;
+            return $one;
         }
 
         let mut base = $self;
-        let mut result = $one_expr;
+        let mut result = $one;
         let mut exp = $rhs;
 
         while exp > 0 {

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::{
-    ConstSemiring, boolean::Boolean, crypto_bigint_uint::Uint, impl_pow_via_repeated_squaring,
-};
+use crate::{ConstSemiring, boolean::Boolean, crypto_bigint_uint::Uint, pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -13,9 +11,7 @@ use core::{
     },
     str::FromStr,
 };
-use crypto_bigint::{
-    CheckedMul as CryptoCheckedMul, CheckedSub as CryptoCheckedSub, ConcatMixed, Integer, Word,
-};
+use crypto_bigint::{CheckedSub as CryptoCheckedSub, Integer, Word};
 use num_traits::{
     CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, ConstOne, ConstZero, One, Pow,
     WrappingAdd, WrappingMul, WrappingSub, Zero,
@@ -23,7 +19,7 @@ use num_traits::{
 use pastey::paste;
 
 #[cfg(feature = "rand")]
-use rand::{distr::StandardUniform, prelude::*, rand_core::TryRngCore};
+use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -87,10 +83,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
         rhs: &Int<RHS_LIMBS>,
     ) -> Int<WIDE_LIMBS>
     where
-        crypto_bigint::Uint<LIMBS>: ConcatMixed<
-                crypto_bigint::Uint<RHS_LIMBS>,
-                MixedOutput = crypto_bigint::Uint<WIDE_LIMBS>,
-            >,
+        crypto_bigint::Uint<LIMBS>:
+            crypto_bigint::Concat<RHS_LIMBS, Output = crypto_bigint::Uint<WIDE_LIMBS>>,
     {
         Int(self.0.concatenating_mul(&rhs.0))
     }
@@ -138,7 +132,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// The number of limbs used on this platform.
     pub const LIMBS: usize = LIMBS;
 
-    define_consts!(MINUS_ONE, SIGN_MASK, FULL_MASK);
+    define_consts!(MINUS_ONE, SIGN_MASK);
 }
 
 //
@@ -222,7 +216,7 @@ impl<const LIMBS: usize> Zero for Int<LIMBS> {
 
     #[inline(always)]
     fn is_zero(&self) -> bool {
-        self.0.is_zero()
+        self.0.is_zero().to_bool_vartime()
     }
 }
 
@@ -337,7 +331,9 @@ impl<const LIMBS: usize> Shr<u32> for Int<LIMBS> {
 impl<const LIMBS: usize> Pow<u32> for Int<LIMBS> {
     type Output = Self;
 
-    impl_pow_via_repeated_squaring!();
+    fn pow(self, rhs: u32) -> Self::Output {
+        pow_via_repeated_squaring!(self, rhs, Self::ONE)
+    }
 }
 
 //
@@ -636,14 +632,14 @@ impl<const LIMBS: usize> IntRing for Int<LIMBS> {
 #[cfg(feature = "rand")]
 impl<const LIMBS: usize> Distribution<Int<LIMBS>> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Int<LIMBS> {
-        crypto_bigint::Random::random(rng)
+        crypto_bigint::Random::random_from_rng(rng)
     }
 }
 
 #[cfg(feature = "rand")]
 impl<const LIMBS: usize> crypto_bigint::Random for Int<LIMBS> {
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        crypto_bigint::Int::try_random(rng).map(Self)
+    fn try_random_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        crypto_bigint::Int::try_random_from_rng(rng).map(Self)
     }
 }
 
@@ -688,31 +684,30 @@ impl<const LIMBS: usize> zeroize::DefaultIsZeroes for Int<LIMBS> {}
 // Traits from crypto_bigint
 //
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeEq for Int<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::CtEq for Int<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeEq::ct_eq(&self.0, &other.0)
+    fn ct_eq(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtEq::ct_eq(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeGreater for Int<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::CtGt for Int<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeGreater::ct_gt(&self.0, &other.0)
+    fn ct_gt(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtGt::ct_gt(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeLess for Int<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::CtLt for Int<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeLess::ct_lt(&self.0, &other.0)
+    fn ct_lt(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtLt::ct_lt(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConditionallySelectable for Int<LIMBS> {
-    fn conditional_select(a: &Self, b: &Self, choice: crypto_bigint::subtle::Choice) -> Self {
-        crypto_bigint::subtle::ConditionallySelectable::conditional_select(&a.0, &b.0, choice)
-            .into()
+impl<const LIMBS: usize> crypto_bigint::CtSelect for Int<LIMBS> {
+    fn ct_select(&self, other: &Self, choice: crypto_bigint::Choice) -> Self {
+        crypto_bigint::CtSelect::ct_select(&self.0, &other.0, choice).into()
     }
 }
 
@@ -789,7 +784,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "`shift` within the bit size of the integer")]
+    #[should_panic(expected = "`shift` exceeds upper bound")]
     fn shl_panics_on_overflow() {
         let x = Int1::from(0x0001_i64);
         let _ = x << 64;
@@ -1080,13 +1075,6 @@ mod tests {
         }
     }
 
-    #[should_panic]
-    #[test]
-    fn from_too_large_primitive() {
-        // Test from_i128
-        let _ = Int1::from(i128::MAX);
-    }
-
     #[test]
     fn edge_cases() {
         // Test operations with MAX values
@@ -1268,31 +1256,29 @@ mod tests {
 
     #[test]
     fn constant_time_traits() {
-        use crypto_bigint::subtle::{
-            Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
-        };
+        use crypto_bigint::{Choice, CtEq, CtGt, CtLt, CtSelect};
 
         let a = Int4::from(10_i64);
         let b = Int4::from(20_i64);
         let c = Int4::from(10_i64);
 
-        // Test ConstantTimeEq
-        assert_eq!(a.ct_eq(&c).unwrap_u8(), 1);
-        assert_eq!(a.ct_eq(&b).unwrap_u8(), 0);
+        // Test CtEq
+        assert_eq!(a.ct_eq(&c).to_u8(), 1);
+        assert_eq!(a.ct_eq(&b).to_u8(), 0);
 
-        // Test ConstantTimeGreater
-        assert_eq!(b.ct_gt(&a).unwrap_u8(), 1);
-        assert_eq!(a.ct_gt(&b).unwrap_u8(), 0);
+        // Test CtGt
+        assert_eq!(b.ct_gt(&a).to_u8(), 1);
+        assert_eq!(a.ct_gt(&b).to_u8(), 0);
 
-        // Test ConstantTimeLess
-        assert_eq!(a.ct_lt(&b).unwrap_u8(), 1);
-        assert_eq!(b.ct_lt(&a).unwrap_u8(), 0);
+        // Test CtLt
+        assert_eq!(a.ct_lt(&b).to_u8(), 1);
+        assert_eq!(b.ct_lt(&a).to_u8(), 0);
 
-        // Test ConditionallySelectable
-        let selected_true = Int4::conditional_select(&a, &b, Choice::from(0));
+        // Test CtSelect
+        let selected_true = a.ct_select(&b, Choice::from(0));
         assert_eq!(selected_true, a);
 
-        let selected_false = Int4::conditional_select(&a, &b, Choice::from(1));
+        let selected_false = a.ct_select(&b, Choice::from(1));
         assert_eq!(selected_false, b);
     }
 
@@ -1356,8 +1342,8 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(1);
 
         // Test crypto_bigint::Random trait
-        let random1: Int4 = crypto_bigint::Random::random(&mut rng);
-        let random2: Int4 = crypto_bigint::Random::random(&mut rng);
+        let random1: Int4 = crypto_bigint::Random::random_from_rng(&mut rng);
+        let random2: Int4 = crypto_bigint::Random::random_from_rng(&mut rng);
 
         // Random values should be different
         assert_ne!(random1, random2);

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boolean::Boolean, impl_pow_via_repeated_squaring};
+use crate::{boolean::Boolean, pow_via_repeated_squaring};
 use alloc::{format, vec::Vec};
 use ark_ff::{BigInt as ArkBigInt, BigInteger as ArkBigInteger};
 use ark_serialize::{
@@ -273,7 +273,9 @@ impl<const N: usize> Shr<u32> for BigInt<N> {
 impl<const N: usize> Pow<u32> for BigInt<N> {
     type Output = Self;
 
-    impl_pow_via_repeated_squaring!();
+    fn pow(self, rhs: u32) -> Self::Output {
+        pow_via_repeated_squaring!(self, rhs, Self::ONE)
+    }
 }
 
 //

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boolean::Boolean, impl_pow_via_repeated_squaring};
+use crate::{boolean::Boolean, pow_via_repeated_squaring};
 use alloc::boxed::Box;
 use core::{
     cmp::Ordering,
@@ -20,7 +20,7 @@ use num_traits::{
 use pastey::paste;
 
 #[cfg(feature = "rand")]
-use rand::rand_core::TryRngCore;
+use rand::rand_core::TryRng;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -140,6 +140,20 @@ impl BoxedUint {
     pub fn nlimbs(&self) -> usize {
         self.0.nlimbs()
     }
+
+    /// See [`crypto_bigint::BoxedUint::zero_with_precision`]
+    pub fn zero_with_precision(at_least_bits_precision: u32) -> Self {
+        Self(crypto_bigint::BoxedUint::zero_with_precision(
+            at_least_bits_precision,
+        ))
+    }
+
+    /// See [`crypto_bigint::BoxedUint::one_with_precision`]
+    pub fn one_with_precision(at_least_bits_precision: u32) -> Self {
+        Self(crypto_bigint::BoxedUint::one_with_precision(
+            at_least_bits_precision,
+        ))
+    }
 }
 
 //
@@ -179,7 +193,7 @@ impl UpperHex for BoxedUint {
 
 impl Hash for BoxedUint {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.hash(state)
+        self.0.as_limbs().hash(state)
     }
 }
 
@@ -209,7 +223,7 @@ impl Zero for BoxedUint {
 
     #[inline(always)]
     fn is_zero(&self) -> bool {
-        self.0.is_zero().into()
+        self.0.is_zero().to_bool_vartime()
     }
 }
 
@@ -322,7 +336,10 @@ impl Shr<u32> for BoxedUint {
 impl Pow<u32> for BoxedUint {
     type Output = Self;
 
-    impl_pow_via_repeated_squaring!();
+    fn pow(self, rhs: u32) -> Self::Output {
+        let precision = self.bits_precision();
+        pow_via_repeated_squaring!(self, rhs, Self::one_with_precision(precision))
+    }
 }
 
 //
@@ -544,14 +561,14 @@ impl IntSemiring for BoxedUint {
 
 #[cfg(feature = "rand")]
 impl crypto_bigint::RandomBits for BoxedUint {
-    fn try_random_bits<R: TryRngCore + ?Sized>(
+    fn try_random_bits<R: TryRng + ?Sized>(
         rng: &mut R,
         bit_length: u32,
     ) -> Result<Self, RandomBitsError<R::Error>> {
         crypto_bigint::BoxedUint::try_random_bits(rng, bit_length).map(Self)
     }
 
-    fn try_random_bits_with_precision<R: TryRngCore + ?Sized>(
+    fn try_random_bits_with_precision<R: TryRng + ?Sized>(
         rng: &mut R,
         bit_length: u32,
         bits_precision: u32,
@@ -600,24 +617,30 @@ impl zeroize::Zeroize for BoxedUint {
 // Traits from crypto_bigint
 //
 
-impl crypto_bigint::subtle::ConstantTimeEq for BoxedUint {
+impl crypto_bigint::CtEq for BoxedUint {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeEq::ct_eq(&self.0, &other.0)
+    fn ct_eq(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtEq::ct_eq(&self.0, &other.0)
     }
 }
 
-impl crypto_bigint::subtle::ConstantTimeGreater for BoxedUint {
+impl crypto_bigint::CtGt for BoxedUint {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeGreater::ct_gt(&self.0, &other.0)
+    fn ct_gt(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtGt::ct_gt(&self.0, &other.0)
     }
 }
 
-impl crypto_bigint::subtle::ConstantTimeLess for BoxedUint {
+impl crypto_bigint::CtLt for BoxedUint {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeLess::ct_lt(&self.0, &other.0)
+    fn ct_lt(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtLt::ct_lt(&self.0, &other.0)
+    }
+}
+
+impl crypto_bigint::CtSelect for BoxedUint {
+    fn ct_select(&self, other: &Self, choice: crypto_bigint::Choice) -> Self {
+        crypto_bigint::CtSelect::ct_select(&self.0, &other.0, choice).into()
     }
 }
 
@@ -1071,23 +1094,30 @@ mod tests {
 
     #[test]
     fn constant_time_traits() {
-        use crypto_bigint::subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
+        use crypto_bigint::{Choice, CtEq, CtGt, CtLt, CtSelect};
 
         let a = BoxedUint::from(10_u64);
         let b = BoxedUint::from(20_u64);
         let c = BoxedUint::from(10_u64);
 
-        // Test ConstantTimeEq
-        assert_eq!(a.ct_eq(&c).unwrap_u8(), 1);
-        assert_eq!(a.ct_eq(&b).unwrap_u8(), 0);
+        // Test CtEq
+        assert_eq!(a.ct_eq(&c).to_u8(), 1);
+        assert_eq!(a.ct_eq(&b).to_u8(), 0);
 
-        // Test ConstantTimeGreater
-        assert_eq!(b.ct_gt(&a).unwrap_u8(), 1);
-        assert_eq!(a.ct_gt(&b).unwrap_u8(), 0);
+        // Test CtGt
+        assert_eq!(b.ct_gt(&a).to_u8(), 1);
+        assert_eq!(a.ct_gt(&b).to_u8(), 0);
 
-        // Test ConstantTimeLess
-        assert_eq!(a.ct_lt(&b).unwrap_u8(), 1);
-        assert_eq!(b.ct_lt(&a).unwrap_u8(), 0);
+        // Test CtLt
+        assert_eq!(a.ct_lt(&b).to_u8(), 1);
+        assert_eq!(b.ct_lt(&a).to_u8(), 0);
+
+        // Test CtSelect
+        let selected_true = a.ct_select(&b, Choice::from(0));
+        assert_eq!(selected_true, a);
+
+        let selected_false = a.ct_select(&b, Choice::from(1));
+        assert_eq!(selected_false, b);
     }
 
     #[test]

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boolean::Boolean, crypto_bigint_int::Int, impl_pow_via_repeated_squaring};
+use crate::{boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -19,7 +19,7 @@ use num_traits::{
 use pastey::paste;
 
 #[cfg(feature = "rand")]
-use rand::{distr::StandardUniform, prelude::*, rand_core::TryRngCore};
+use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -219,7 +219,7 @@ impl<const LIMBS: usize> Zero for Uint<LIMBS> {
 
     #[inline(always)]
     fn is_zero(&self) -> bool {
-        self.0.is_zero()
+        self.0.is_zero().to_bool_vartime()
     }
 }
 
@@ -340,7 +340,9 @@ impl<const LIMBS: usize> Shr<u32> for Uint<LIMBS> {
 impl<const LIMBS: usize> Pow<u32> for Uint<LIMBS> {
     type Output = Self;
 
-    impl_pow_via_repeated_squaring!();
+    fn pow(self, rhs: u32) -> Self::Output {
+        pow_via_repeated_squaring!(self, rhs, Self::ONE)
+    }
 }
 
 //
@@ -373,7 +375,11 @@ impl<const LIMBS: usize> CheckedMul for Uint<LIMBS> {
     fn checked_mul(&self, other: &Self) -> Option<Self> {
         // Use widening_mul which returns (lo, hi)
         let (lo, hi) = self.0.widening_mul(&other.0);
-        if hi.is_zero() { Some(Self(lo)) } else { None }
+        if hi.is_zero().to_bool_vartime() {
+            Some(Self(lo))
+        } else {
+            None
+        }
     }
 }
 
@@ -577,14 +583,14 @@ impl<const LIMBS: usize> IntSemiring for Uint<LIMBS> {
 #[cfg(feature = "rand")]
 impl<const LIMBS: usize> Distribution<Uint<LIMBS>> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Uint<LIMBS> {
-        crypto_bigint::Random::random(rng)
+        crypto_bigint::Random::random_from_rng(rng)
     }
 }
 
 #[cfg(feature = "rand")]
 impl<const LIMBS: usize> crypto_bigint::Random for Uint<LIMBS> {
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        crypto_bigint::Uint::try_random(rng).map(Self)
+    fn try_random_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        crypto_bigint::Uint::try_random_from_rng(rng).map(Self)
     }
 }
 
@@ -629,31 +635,30 @@ impl<const LIMBS: usize> zeroize::DefaultIsZeroes for Uint<LIMBS> {}
 // Traits from crypto_bigint
 //
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeEq for Uint<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::CtEq for Uint<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeEq::ct_eq(&self.0, &other.0)
+    fn ct_eq(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtEq::ct_eq(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeGreater for Uint<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::CtGt for Uint<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeGreater::ct_gt(&self.0, &other.0)
+    fn ct_gt(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtGt::ct_gt(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeLess for Uint<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::CtLt for Uint<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
-        crypto_bigint::subtle::ConstantTimeLess::ct_lt(&self.0, &other.0)
+    fn ct_lt(&self, other: &Self) -> crypto_bigint::Choice {
+        crypto_bigint::CtLt::ct_lt(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> crypto_bigint::subtle::ConditionallySelectable for Uint<LIMBS> {
-    fn conditional_select(a: &Self, b: &Self, choice: crypto_bigint::subtle::Choice) -> Self {
-        crypto_bigint::subtle::ConditionallySelectable::conditional_select(&a.0, &b.0, choice)
-            .into()
+impl<const LIMBS: usize> crypto_bigint::CtSelect for Uint<LIMBS> {
+    fn ct_select(&self, other: &Self, choice: crypto_bigint::Choice) -> Self {
+        crypto_bigint::CtSelect::ct_select(&self.0, &other.0, choice).into()
     }
 }
 
@@ -719,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "`shift` within the bit size of the integer")]
+    #[should_panic(expected = "`shift` exceeds upper bound")]
     fn shl_panics_on_overflow() {
         let x = Uint1::from(0x0001_u64);
         let _ = x << 64;
@@ -1125,31 +1130,29 @@ mod tests {
 
     #[test]
     fn constant_time_traits() {
-        use crypto_bigint::subtle::{
-            Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
-        };
+        use crypto_bigint::{Choice, CtEq, CtGt, CtLt, CtSelect};
 
         let a = Uint4::from(10_u64);
         let b = Uint4::from(20_u64);
         let c = Uint4::from(10_u64);
 
-        // Test ConstantTimeEq
-        assert_eq!(a.ct_eq(&c).unwrap_u8(), 1);
-        assert_eq!(a.ct_eq(&b).unwrap_u8(), 0);
+        // Test CtEq
+        assert_eq!(a.ct_eq(&c).to_u8(), 1);
+        assert_eq!(a.ct_eq(&b).to_u8(), 0);
 
-        // Test ConstantTimeGreater
-        assert_eq!(b.ct_gt(&a).unwrap_u8(), 1);
-        assert_eq!(a.ct_gt(&b).unwrap_u8(), 0);
+        // Test CtGt
+        assert_eq!(b.ct_gt(&a).to_u8(), 1);
+        assert_eq!(a.ct_gt(&b).to_u8(), 0);
 
-        // Test ConstantTimeLess
-        assert_eq!(a.ct_lt(&b).unwrap_u8(), 1);
-        assert_eq!(b.ct_lt(&a).unwrap_u8(), 0);
+        // Test CtLt
+        assert_eq!(a.ct_lt(&b).to_u8(), 1);
+        assert_eq!(b.ct_lt(&a).to_u8(), 0);
 
-        // Test ConditionallySelectable
-        let selected_true = Uint4::conditional_select(&a, &b, Choice::from(0));
+        // Test CtSelect
+        let selected_true = a.ct_select(&b, Choice::from(0));
         assert_eq!(selected_true, a);
 
-        let selected_false = Uint4::conditional_select(&a, &b, Choice::from(1));
+        let selected_false = a.ct_select(&b, Choice::from(1));
         assert_eq!(selected_false, b);
     }
 
@@ -1201,8 +1204,8 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(1);
 
         // Test crypto_bigint::Random trait
-        let random1: Uint4 = crypto_bigint::Random::random(&mut rng);
-        let random2: Uint4 = crypto_bigint::Random::random(&mut rng);
+        let random1: Uint4 = <Uint4 as crypto_bigint::Random>::random_from_rng(&mut rng);
+        let random2: Uint4 = <Uint4 as crypto_bigint::Random>::random_from_rng(&mut rng);
 
         // Random values should be different
         assert_ne!(random1, random2);


### PR DESCRIPTION
Updated dependencies:

* `crypto-bigint` bumped from `0.7.0-rc` unstable branch to a more stable `0.7`
*  `rand` - from `0.9` to `0.10` (needs to align with `crypto-bigint`)

A few more related changes:
* Added `zero_with_precision` and `one_with_precision` to `BoxedUint`
* Added previously forgotten `impl CtSelect` for `BoxedUint`
* Slightly tweaked `pow_via_repeated_squaring` to accommodate `BoxedUint`  initial bit precision