### PR TITLE
No-overhead fields

### DIFF
--- a/benches/boxed_monty_field_benches.rs
+++ b/benches/boxed_monty_field_benches.rs
@@ -1,26 +1,28 @@
-#![allow(non_local_definitions)]
-#![allow(clippy::eq_op)]
-
 mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{Odd, modular::BoxedMontyParams};
-use crypto_primitives::crypto_bigint_boxed_monty::BoxedMontyField;
+use crypto_primitives::{ProjectElement, crypto_bigint_boxed_monty::BoxedMontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 
-fn bench_config() -> BoxedMontyParams {
+fn bench_config() -> BoxedMontyField {
     let modulus = crypto_bigint::BoxedUint::from_be_hex(
         "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
         256,
     )
     .unwrap();
     let modulus = Odd::new(modulus).expect("modulus should be odd");
-    BoxedMontyParams::new(modulus)
+    BoxedMontyField::wrap(BoxedMontyParams::new(modulus))
 }
 
 pub fn boxed_monty_field_benches(c: &mut Criterion) {
-    field_benchmarks::<BoxedMontyField>(c, "Boxed Monty Field Arithmetic", &bench_config());
+    field_benchmarks(
+        c,
+        "Boxed Monty Field Arithmetic",
+        &bench_config(),
+        |config, num| config.project(&num),
+    );
 }
 
 criterion_group!(benches, boxed_monty_field_benches);

--- a/benches/boxed_monty_field_benches.rs
+++ b/benches/boxed_monty_field_benches.rs
@@ -2,7 +2,7 @@ mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{Odd, modular::BoxedMontyParams};
-use crypto_primitives::{ProjectElementDynamic, crypto_bigint_boxed_monty::BoxedMontyField};
+use crypto_primitives::{ProjectElementWithConfig, crypto_bigint_boxed_monty::BoxedMontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 

--- a/benches/boxed_monty_field_benches.rs
+++ b/benches/boxed_monty_field_benches.rs
@@ -2,7 +2,7 @@ mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{Odd, modular::BoxedMontyParams};
-use crypto_primitives::{ProjectElement, crypto_bigint_boxed_monty::BoxedMontyField};
+use crypto_primitives::{ProjectElementDynamic, crypto_bigint_boxed_monty::BoxedMontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 

--- a/benches/const_monty_field_benches.rs
+++ b/benches/const_monty_field_benches.rs
@@ -1,11 +1,8 @@
-#![allow(non_local_definitions)]
-#![allow(clippy::eq_op)]
-
 mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{U256, const_monty_params};
-use crypto_primitives::crypto_bigint_const_monty::ConstMontyField;
+use crypto_primitives::{FixedFieldConfig, crypto_bigint_const_monty::ConstMontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 
@@ -15,8 +12,15 @@ const_monty_params!(
     "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33"
 );
 
+type F = ConstMontyField<Params, { U256::LIMBS }>;
+
 pub fn const_monty_field_benches(c: &mut Criterion) {
-    field_benchmarks::<ConstMontyField<Params, _>>(c, "Const Monty Field Arithmetic", &());
+    field_benchmarks(
+        c,
+        "Const Monty Field Arithmetic",
+        &FixedFieldConfig::<F>::default(),
+        |_, num| F::from(num),
+    );
 }
 
 criterion_group!(benches, const_monty_field_benches);

--- a/benches/const_monty_field_benches.rs
+++ b/benches/const_monty_field_benches.rs
@@ -2,7 +2,7 @@ mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{U256, const_monty_params};
-use crypto_primitives::{FixedFieldConfig, crypto_bigint_const_monty::ConstMontyField};
+use crypto_primitives::{FixedConfig, crypto_bigint_const_monty::ConstMontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 
@@ -18,7 +18,7 @@ pub fn const_monty_field_benches(c: &mut Criterion) {
     field_benchmarks(
         c,
         "Const Monty Field Arithmetic",
-        &FixedFieldConfig::<F>::default(),
+        &FixedConfig::<F>::default(),
         |_, num| F::from(num),
     );
 }

--- a/benches/field_ops_bench_common.rs
+++ b/benches/field_ops_bench_common.rs
@@ -1,9 +1,9 @@
 use std::hint::black_box;
 
 use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration};
-use crypto_primitives::FieldConfig;
+use crypto_primitives::BaseFieldConfig;
 
-fn bench_random_field<C: FieldConfig>(
+fn bench_random_field<C: BaseFieldConfig>(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
     num: u64,
     config: &C,
@@ -107,7 +107,7 @@ fn bench_random_field<C: FieldConfig>(
     });
 }
 
-pub fn field_benchmarks<C: FieldConfig>(
+pub fn field_benchmarks<C: BaseFieldConfig>(
     c: &mut Criterion,
     name: &str,
     config: &C,

--- a/benches/field_ops_bench_common.rs
+++ b/benches/field_ops_bench_common.rs
@@ -1,183 +1,76 @@
-#![allow(non_local_definitions)]
-#![allow(clippy::eq_op)]
+use std::hint::black_box;
 
-use std::{
-    hint::black_box,
-    iter::{Product, Sum},
-    ops::{Add, Div, Mul},
-};
+use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use crypto_primitives::FieldConfig;
 
-use criterion::{AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration};
-use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
-
-fn bench_random_field<F>(
+fn bench_random_field<C: FieldConfig>(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
     num: u64,
-    config: &F::Config,
-) where
-    for<'a> &'a F: Add<&'a F> + Mul<&'a F> + Div<&'a F>,
-    F: PrimeField + FromPrimitiveWithConfig + for<'a> Sum<&'a F> + for<'a> Product<&'a F>,
-{
-    let field_elem = F::from_with_cfg(num, config);
-    let param = format!("Param = {}", num);
-
-    group.bench_with_input(
-        BenchmarkId::new("Mul owned by owned", &param),
-        &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || {
-                    (
-                        vec![unop_elem.clone(); 10000],
-                        vec![unop_elem.clone(); 10000],
-                    )
-                },
-                |(lhs, rhs)| {
-                    for (lhs, rhs) in lhs.into_iter().zip(rhs) {
-                        let _ = black_box(lhs * rhs);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
-
-    group.bench_with_input(
-        BenchmarkId::new("Mul owned by ref", &param),
-        &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || {
-                    (
-                        vec![unop_elem.clone(); 10000],
-                        vec![unop_elem.clone(); 10000],
-                    )
-                },
-                |(lhs, rhs)| {
-                    for (lhs, rhs) in lhs.into_iter().zip(rhs) {
-                        let _ = black_box(lhs * &rhs);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+    config: &C,
+    project: &impl Fn(&C, u64) -> C::Element,
+) {
+    let field_elem = project(config, num);
+    let param = format!("Param = {num}");
 
     group.bench_with_input(
         BenchmarkId::new("Mul ref by ref", &param),
         &field_elem,
-        |b, unop_elem| {
+        |b, elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(unop_elem * unop_elem);
+                    let _ = black_box(config.mul(elem, elem));
                 }
             });
         },
     );
 
     group.bench_with_input(
-        BenchmarkId::new("Add owned to owned", &param),
+        BenchmarkId::new("Mul assign", &param),
         &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || {
-                    (
-                        vec![unop_elem.clone(); 10000],
-                        vec![unop_elem.clone(); 10000],
-                    )
-                },
-                |(lhs, rhs)| {
-                    for (lhs, rhs) in lhs.into_iter().zip(rhs) {
-                        let _ = black_box(lhs + rhs);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
-
-    group.bench_with_input(
-        BenchmarkId::new("Add owned to ref", &param),
-        &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || {
-                    (
-                        vec![unop_elem.clone(); 10000],
-                        vec![unop_elem.clone(); 10000],
-                    )
-                },
-                |(lhs, rhs)| {
-                    for (lhs, rhs) in lhs.into_iter().zip(rhs) {
-                        let _ = black_box(lhs + &rhs);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
+        |b, elem| {
+            b.iter(|| {
+                let mut acc = elem.clone();
+                for _ in 0..10000 {
+                    config.mul_assign(&mut acc, elem);
+                }
+                black_box(acc)
+            });
         },
     );
 
     group.bench_with_input(
         BenchmarkId::new("Add ref to ref", &param),
         &field_elem,
-        |b, unop_elem| {
+        |b, elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(unop_elem + unop_elem);
+                    let _ = black_box(config.add(elem, elem));
                 }
             });
         },
     );
 
     group.bench_with_input(
-        BenchmarkId::new("Div owned by owned", &param),
+        BenchmarkId::new("Add assign", &param),
         &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || {
-                    (
-                        vec![unop_elem.clone(); 10000],
-                        vec![unop_elem.clone(); 10000],
-                    )
-                },
-                |(lhs, rhs)| {
-                    for (lhs, rhs) in lhs.into_iter().zip(rhs) {
-                        let _ = black_box(lhs / rhs);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
-
-    group.bench_with_input(
-        BenchmarkId::new("Div owned by ref", &param),
-        &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || {
-                    (
-                        vec![unop_elem.clone(); 10000],
-                        vec![unop_elem.clone(); 10000],
-                    )
-                },
-                |(lhs, rhs)| {
-                    for (lhs, rhs) in lhs.into_iter().zip(rhs) {
-                        let _ = black_box(lhs / &rhs);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
+        |b, elem| {
+            b.iter(|| {
+                let mut acc = elem.clone();
+                for _ in 0..10000 {
+                    config.add_assign(&mut acc, elem);
+                }
+                black_box(acc)
+            });
         },
     );
 
     group.bench_with_input(
         BenchmarkId::new("Div ref by ref", &param),
         &field_elem,
-        |b, unop_elem| {
+        |b, elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(unop_elem / unop_elem);
+                    let _ = black_box(config.div(elem, elem));
                 }
             });
         },
@@ -186,16 +79,12 @@ fn bench_random_field<F>(
     group.bench_with_input(
         BenchmarkId::new("Negation", &param),
         &field_elem,
-        |b, unop_elem| {
-            b.iter_batched(
-                || vec![unop_elem.clone(); 10000],
-                |unop_elem| {
-                    for x in unop_elem.into_iter() {
-                        let _ = black_box(-x);
-                    }
-                },
-                BatchSize::SmallInput,
-            );
+        |b, elem| {
+            b.iter(|| {
+                for _ in 0..10000 {
+                    let _ = black_box(config.neg(elem));
+                }
+            });
         },
     );
 
@@ -204,7 +93,7 @@ fn bench_random_field<F>(
     group.bench_with_input(BenchmarkId::new("Sum", &param), &v, |b, v| {
         b.iter(|| {
             for _ in 0..10000 {
-                let _ = black_box(F::sum(v.iter()));
+                let _ = black_box(config.sum_refs(v.iter()));
             }
         });
     });
@@ -212,25 +101,26 @@ fn bench_random_field<F>(
     group.bench_with_input(BenchmarkId::new("Product", &param), &v, |b, v| {
         b.iter(|| {
             for _ in 0..10000 {
-                let _ = black_box(F::product(v.iter()));
+                let _ = black_box(config.product_refs(v.iter()));
             }
         });
     });
 }
 
-pub fn field_benchmarks<F>(c: &mut Criterion, name: &str, config: &F::Config)
-where
-    for<'a> &'a F: Add<&'a F> + Mul<&'a F> + Div<&'a F>,
-    F: PrimeField + FromPrimitiveWithConfig + for<'a> Sum<&'a F> + for<'a> Product<&'a F>,
-{
+pub fn field_benchmarks<C: FieldConfig>(
+    c: &mut Criterion,
+    name: &str,
+    config: &C,
+    project: impl Fn(&C, u64) -> C::Element,
+) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
 
     let mut group = c.benchmark_group(name);
     group.plot_config(plot_config);
 
-    bench_random_field::<F>(&mut group, 695962179703_u64, config);
-    bench_random_field::<F>(&mut group, 2345695962179703_u64, config);
-    bench_random_field::<F>(&mut group, 111111111111111111_u64, config);
-    bench_random_field::<F>(&mut group, 12345678124578658568_u64, config);
+    bench_random_field(&mut group, 695962179703_u64, config, &project);
+    bench_random_field(&mut group, 2345695962179703_u64, config, &project);
+    bench_random_field(&mut group, 111111111111111111_u64, config, &project);
+    bench_random_field(&mut group, 12345678124578658568_u64, config, &project);
     group.finish();
 }

--- a/benches/field_ops_bench_common.rs
+++ b/benches/field_ops_bench_common.rs
@@ -1,9 +1,9 @@
 use std::hint::black_box;
 
 use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration};
-use crypto_primitives::BaseFieldConfig;
+use crypto_primitives::FieldConfig;
 
-fn bench_random_field<C: BaseFieldConfig>(
+fn bench_random_field<C: FieldConfig>(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
     num: u64,
     config: &C,
@@ -107,7 +107,7 @@ fn bench_random_field<C: BaseFieldConfig>(
     });
 }
 
-pub fn field_benchmarks<C: BaseFieldConfig>(
+pub fn field_benchmarks<C: FieldConfig>(
     c: &mut Criterion,
     name: &str,
     config: &C,

--- a/benches/monty_field_benches.rs
+++ b/benches/monty_field_benches.rs
@@ -1,26 +1,28 @@
-#![allow(non_local_definitions)]
-#![allow(clippy::eq_op)]
-
 mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{Odd, modular::FixedMontyParams};
-use crypto_primitives::crypto_bigint_monty::MontyField;
+use crypto_primitives::{ProjectElement, crypto_bigint_monty::MontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 
 const LIMBS: usize = 4;
 
-fn bench_config() -> FixedMontyParams<LIMBS> {
+fn bench_config() -> MontyField<LIMBS> {
     let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
         "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
     );
     let modulus = Odd::new(modulus).expect("modulus should be odd");
-    FixedMontyParams::new(modulus)
+    MontyField::wrap(FixedMontyParams::new(modulus))
 }
 
 fn monty_field_benches(c: &mut Criterion) {
-    field_benchmarks::<MontyField<_>>(c, "Monty Field Arithmetic", &bench_config());
+    field_benchmarks(
+        c,
+        "Monty Field Arithmetic",
+        &bench_config(),
+        |config, num| config.project(&num),
+    );
 }
 
 criterion_group!(benches, monty_field_benches);

--- a/benches/monty_field_benches.rs
+++ b/benches/monty_field_benches.rs
@@ -2,7 +2,7 @@ mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{Odd, modular::FixedMontyParams};
-use crypto_primitives::{ProjectElementDynamic, crypto_bigint_monty::MontyField};
+use crypto_primitives::{ProjectElementWithConfig, crypto_bigint_monty::MontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 

--- a/benches/monty_field_benches.rs
+++ b/benches/monty_field_benches.rs
@@ -2,7 +2,7 @@ mod field_ops_bench_common;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{Odd, modular::FixedMontyParams};
-use crypto_primitives::{ProjectElement, crypto_bigint_monty::MontyField};
+use crypto_primitives::{ProjectElementDynamic, crypto_bigint_monty::MontyField};
 
 use crate::field_ops_bench_common::field_benchmarks;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -41,11 +41,11 @@ pub trait FixedField:
     + Pow<u32, Output=Self>
     + Inv<Output = Option<Self>>
     // Arithmetic operations consuming rhs
-    //+ Pow<Self::Integer, Output=Self>
+    + Pow<Self::Integer, Output=Self>
     + Div<Output=Self>
     + DivAssign
     // Arithmetic operations with rhs reference
-    //+ for<'a> Pow<&'a Self::Integer, Output=Self>
+    + for<'a> Pow<&'a Self::Integer, Output=Self>
     + for<'a> Div<&'a Self, Output=Self>
     + for<'a> DivAssign<&'a Self>
     // Conversion
@@ -77,7 +77,7 @@ pub trait FixedField:
 
 /// Base (non-extension) prime field with elements being self-sufficient, but
 /// whose metadata like modulus is not necessarily known at compile-time.
-pub trait FixedBaseField: FixedField {
+pub trait FixedBaseField: FixedField + LiftToIntegerStatic {
     fn modulus() -> Self::Integer;
 
     fn modulus_minus_one_div_two() -> Self::Integer;
@@ -85,7 +85,7 @@ pub trait FixedBaseField: FixedField {
 
 /// Base (non-extension) prime field whose modulus and other metadata are
 /// constant values known at compile time.
-pub trait ConstBaseField: FixedField + ConstRing {
+pub trait ConstBaseField: FixedField + LiftToIntegerStatic + ConstRing {
     const MODULUS: Self::Integer;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;
 }
@@ -135,7 +135,7 @@ macro_rules! delegate_to_ref_binary {
 // FieldConfig (both static and dynamic)
 //
 
-pub trait FieldConfigOps {
+pub trait FieldConfigOps: WithAssociatedInteger {
     type Element: Debug + Eq + Clone + Send + Sync + 'static;
 
     fn is_zero(&self, value: &Self::Element) -> bool;
@@ -177,7 +177,7 @@ pub trait FieldConfigOps {
     }
 
     /// x ** y
-    fn pow(&self, x: &Self::Element, y: &Self::Element) -> Self::Element { todo!() }
+    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element;
 
     /// x ** y
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element;
@@ -213,7 +213,7 @@ pub trait FieldConfigOps {
 
     delegate_to_ref_binary! {
         /// x **= y
-        pow
+        pow(&Self::Integer)
     }
 
     delegate_to_ref_binary! {
@@ -272,7 +272,7 @@ pub trait FieldConfigOps {
 ///
 /// Constant prime fields are considered a special case of dynamic prime fields.
 pub trait FieldConfig:
-    Sized + FieldConfigOps + WithAssociatedInteger + ProjectElement<Self::Integer>
+    Sized + WithAssociatedInteger + FieldConfigOps + ProjectElement<<Self as WithAssociatedInteger>::Integer>
 {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError>;
 
@@ -287,7 +287,10 @@ pub trait FieldConfig:
 #[derive(Clone, Copy, Default, Debug)]
 pub struct FixedFieldConfig<F: FixedBaseField>(PhantomData<F>);
 
-impl<F: FixedBaseField> FieldConfigOps for FixedFieldConfig<F> {
+impl<F> FieldConfigOps for FixedFieldConfig<F>
+where
+    F: FixedBaseField + LiftToIntegerStatic,
+{
     type Element = F;
 
     #[inline(always)]
@@ -315,10 +318,12 @@ impl<F: FixedBaseField> FieldConfigOps for FixedFieldConfig<F> {
         x.clone() + y
     }
 
+    #[inline(always)]
     fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
         x.clone() - y
     }
 
+    #[inline(always)]
     fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
         x.clone().inv()
     }
@@ -328,16 +333,21 @@ impl<F: FixedBaseField> FieldConfigOps for FixedFieldConfig<F> {
         x.clone() * y
     }
 
-    fn pow(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
-        todo!() //x.clone().pow(y)
+    #[inline(always)]
+    fn pow(&self, x: &Self::Element, y: &F::Integer) -> Self::Element {
+        x.clone().pow(y)
     }
 
+    #[inline(always)]
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
         x.clone().pow(y)
     }
 }
 
-impl<F: FixedBaseField> FieldConfig for FixedFieldConfig<F> {
+impl<F> FieldConfig for FixedFieldConfig<F>
+where
+    F: FixedBaseField + LiftToIntegerStatic,
+{
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
         if *modulus == F::modulus() {
             Ok(Self::default())
@@ -361,14 +371,20 @@ impl<F: FixedBaseField> WithAssociatedInteger for FixedFieldConfig<F> {
     type Integer = F::Integer;
 }
 
-impl<F: FixedBaseField + LiftToIntegerStatic> LiftToIntegerDynamic for FixedFieldConfig<F> {
+impl<F> LiftToIntegerDynamic for FixedFieldConfig<F>
+where
+    F: FixedBaseField + LiftToIntegerStatic,
+{
     #[inline(always)]
     fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
         LiftToIntegerStatic::lift_to_integer(value)
     }
 }
 
-impl<F: FixedBaseField> ProjectElement<F::Integer> for FixedFieldConfig<F> {
+impl<F> ProjectElement<F::Integer> for FixedFieldConfig<F>
+where
+    F: FixedBaseField + LiftToIntegerStatic,
+{
     fn project(&self, value: &F::Integer) -> Self::Element {
         F::from(value)
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,39 +1,32 @@
 //! This module defines **fields** - sets where addition and
 //! multiplication are defined with their respective inverse operations.
-//! Supports both static and dynamic fields (via general [`FieldConfig`]).
+//!
+//! See the [crate-level documentation](crate) for the overall element/config
+//! structure.
 //!
 //! Currently, this only defines **base** (non-extension) prime fields, whose
 //! modulus is an integer, but can be seamlessly extended to support extension
 //! fields in the future as well.
 //!
-//! - [`FixedField`] and [`ConstField`] are fields where each element is
-//!   self-sufficient. Instances carry around all metadata necessary to perform
-//!   operations, so they can be used normally as e.g. `a + b`. Every
-//!   [`ConstField`] is a [`FixedField`] as well.
+//! - [`WithAssociatedInteger`] defines the associated integer type for a field,
+//!   which is used for exponents and order, as well as the modulus for base
+//!   fields.
 //!
-//! - [`FieldConfig`] is a field configuration that carries the metadata needed
-//!   to perform operations that the elements themselves do not carry, e.g. a
-//!   modulus only available at runtime. It's used as `f.add(&a, &b)`. Bridge
-//!   between this and [`FixedField`] is [`FixedFieldConfig`].
+//! - [`WithExtensionDegree`] defines the field's degree over its prime subfield
+//!   (1 for base fields).
 //!
-//! - [`WithAssociatedInteger`] is a trait that defines the associated integer
-//!   type for a field, which is used for exponents and order, as well as the
-//!   modulus for base fields.
+//! - Base field variants of fields are [`BaseField`], [`ConstBaseField`] and
+//!   [`BaseFieldConfig`] that define an integer `modulus`. They additionally
+//!   allow lifting elements to the associated integer type (and, on the config
+//!   side, projecting from it).
 //!
-//! - [`LiftElementDynamic`] and [`ProjectElementDynamic`] define how to lift a
-//!   field element to a chosen type and project it back, for a general
-//!   [`FieldConfig`]; base fields lift to their associated integer type (see
-//!   [`BaseFieldConfig`]).
+//! - [`LiftElementWithConfig`] and [`ProjectElementWithConfig`] define how to
+//!   lift a field element to a chosen type and project it back to the field.
 //!
-//! - Lift/project counterpart for fixed fields is asymmetric - lifting is done
-//!   via [`LiftElementStatic`] (by reference, avoiding a copy of the element)
-//!   while projection is done with [`From`] (both by reference and by value),
-//!   e.g. `F::from(f.lift()) == f`.
-//!
-//! - Base field variants of fields are [`FixedBaseField`], [`ConstBaseField`]
-//!   and [`BaseFieldConfig`]. They additionally allow lifting elements to the
-//!   associated integer type (and, on the config side, projecting from it).
-//!   They also define an integer `modulus`.
+//! - Lift/project counterpart for self-sufficient elements is asymmetric -
+//!   lifting is done via [`LiftElement`] (by reference, avoiding a copy of the
+//!   element) while projection is done with [`From`] (both by reference and by
+//!   value), e.g. `F::from(f.lift()) == f`.
 
 #[cfg(feature = "ark_ff")]
 pub mod ark_ff_field;
@@ -47,28 +40,30 @@ pub mod crypto_bigint_const_monty;
 pub mod crypto_bigint_monty;
 pub mod f2;
 
-use crate::{ConstRing, ConstSemiring, FixedRing, IntRing, IntSemiring, Semiring, ring::Ring};
+use crate::{
+    ConstRing, FixedConfig, IntSemiring, Ring, RingConfig, SemiringConfig, SetConfig, SetElement,
+    delegate_to_ref_binary,
+};
 use core::{
     fmt::Debug,
-    marker::PhantomData,
     ops::{Div, DivAssign, Neg},
 };
-use num_traits::{Inv, Pow, Zero};
+use num_traits::{Bounded, Inv, Pow, Zero};
 use pastey::paste;
 use thiserror::Error;
 
 //
-// FixedField (static and const)
+// Field (static and const)
 //
 
-/// Element of a field (F) - a set where addition and multiplication are
-/// defined with their respective inverse operations.
+/// See [module-level documentation](crate::field).
 ///
-/// This is a general trait for all fields, base and extension.
-pub trait FixedField:
-    FixedRing
+/// This is a general trait for all fields, [base](BaseField) and extension.
+pub trait Field:
+    SetElement
+    + Ring
     + WithAssociatedInteger
-    + Pow<u32, Output=Self>
+    + WithExtensionDegree
     + Inv<Output = Option<Self>>
     // Arithmetic operations consuming rhs
     + Pow<Self::Integer, Output=Self>
@@ -83,109 +78,111 @@ pub trait FixedField:
     + From<u128>
     + From<Self::Integer>
     + for<'a> From<&'a Self::Integer>
-    + 'static
 {
 }
 
-/// [`FixedField`] with a bunch of values known at compile time.
-pub trait ConstField: FixedField + ConstRing {}
-impl<F: FixedField + ConstRing> ConstField for F {}
+/// The field's degree over its prime subfield; 1 for base fields.
+pub trait WithExtensionDegree {
+    // Note that extension degree does not require config.
+    // However, we still have to manually implement it for BaseFieldConfigs to avoid
+    // conflicting blanket implementation with BaseField.
+
+    /// Extension degree of the field.
+    fn extension_degree() -> u64;
+}
+
+impl<T> Field for T where
+    T: SetElement
+        + Ring
+        + WithAssociatedInteger
+        + WithExtensionDegree
+        + Inv<Output = Option<Self>>
+        // Arithmetic operations consuming rhs
+        + Pow<Self::Integer, Output = Self>
+        + Div<Output = Self>
+        + DivAssign
+        // Arithmetic operations with rhs reference
+        + for<'a> Pow<&'a Self::Integer, Output = Self>
+        + for<'a> Div<&'a Self, Output = Self>
+        + for<'a> DivAssign<&'a Self>
+        // Conversion
+        + From<u64>
+        + From<u128>
+        + From<Self::Integer>
+        + for<'a> From<&'a Self::Integer>
+{
+}
+
+/// [`Field`] with a bunch of values known at compile time.
+pub trait ConstField: Field + ConstRing {}
+impl<F: Field + ConstRing> ConstField for F {}
 
 /// Base (non-extension) prime field with elements being self-sufficient, but
 /// whose metadata like modulus is not necessarily known at compile-time.
-pub trait FixedBaseField: FixedField + LiftElementStatic<Self::Integer> {
+pub trait BaseField:
+    Field + Bounded + LiftElement<<Self as WithAssociatedInteger>::Integer>
+{
     fn modulus() -> Self::Integer;
 
     /// (mod - 1) / 2
     fn modulus_minus_one_div_two() -> Self::Integer;
 }
 
+impl<F: BaseField> WithExtensionDegree for F {
+    fn extension_degree() -> u64 {
+        1
+    }
+}
+
 /// Base (non-extension) prime field whose modulus and other metadata are
 /// constant values known at compile time.
-pub trait ConstBaseField: ConstField + LiftElementStatic<Self::Integer> {
+pub trait ConstBaseField:
+    ConstField + Bounded + LiftElement<<Self as WithAssociatedInteger>::Integer>
+{
     const MODULUS: Self::Integer;
 
     /// (mod - 1) / 2
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;
 }
 
-impl<T: ConstBaseField> FixedBaseField for T {
+impl<T: ConstBaseField> BaseField for T {
     fn modulus() -> Self::Integer {
         Self::MODULUS
     }
 
+    /// (mod - 1) / 2
     fn modulus_minus_one_div_two() -> Self::Integer {
         Self::MODULUS_MINUS_ONE_DIV_TWO
     }
-}
-
-impl<F: FixedField + IntSemiring> IntRing for F {
-    #[inline(always)]
-    fn checked_abs(&self) -> Option<Self> {
-        Some(self.clone())
-    }
-
-    #[inline(always)]
-    fn is_positive(&self) -> bool {
-        !self.is_zero()
-    }
-
-    #[inline(always)]
-    fn is_negative(&self) -> bool {
-        false
-    }
-}
-
-macro_rules! delegate_to_ref_binary {
-    ($(#[$attr:meta])* $op:ident) => {
-        delegate_to_ref_binary!($(#[$attr])* $op(&Self::Element));
-    };
-    ($(#[$attr:meta])* $op:ident($rhs_type:ty)) => {
-        paste! {
-            $(#[$attr])*
-            fn [<$op _assign>](&self, x: &mut Self::Element, y: $rhs_type) {
-                *x = self.$op(x, y);
-            }
-        }
-    };
 }
 
 //
 // FieldConfig (both static and dynamic)
 //
 
-pub trait FieldConfig: WithAssociatedInteger {
-    type Element: Debug + Eq + Clone + Send + Sync + 'static;
-
-    fn is_zero(&self, value: &Self::Element) -> bool;
-
-    fn zero(&self) -> Self::Element;
-
-    fn one(&self) -> Self::Element;
-
+/// See [module-level documentation](crate::field).
+///
+/// This is a general trait for all fields, [base](BaseFieldConfig) and
+/// extension.
+pub trait FieldConfig: RingConfig + WithAssociatedInteger + WithExtensionDegree {
     //
     // Operations on refs
     //
 
-    /// -x
-    fn neg(&self, x: &Self::Element) -> Self::Element;
-
-    /// x + y
-    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
-
-    /// x - y
-    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
-
     /// 1/x
     fn inv(&self, x: &Self::Element) -> Option<Self::Element>;
-
-    /// x * y
-    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
 
     /// x / y
     fn div(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
         self.checked_div(x, y).expect("Division by zero")
     }
+
+    /// x ** y
+    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element;
+
+    //
+    // Checked operations on refs
+    //
 
     /// x / y, [`None`] if `y == 0`
     #[inline(always)]
@@ -193,35 +190,11 @@ pub trait FieldConfig: WithAssociatedInteger {
         Some(self.mul(x, &self.inv(y)?))
     }
 
-    /// x ** y
-    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element;
-
-    /// x ** y
-    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element;
+    // NOTE: `pow` cannot fail
 
     //
     // Operations on mutable refs
     //
-
-    // x = -x;
-    fn neg_assign(&self, x: &mut Self::Element) {
-        *x = self.neg(x);
-    }
-
-    delegate_to_ref_binary! {
-        /// x += y
-        add
-    }
-
-    delegate_to_ref_binary! {
-        /// x -= y
-        sub
-    }
-
-    delegate_to_ref_binary! {
-        /// x *= y
-        mul
-    }
 
     delegate_to_ref_binary! {
         /// x /= y
@@ -232,71 +205,21 @@ pub trait FieldConfig: WithAssociatedInteger {
         /// x **= y
         pow(&Self::Integer)
     }
-
-    delegate_to_ref_binary! {
-        /// x **= y
-        pow_u32(u32)
-    }
-
-    //
-    // Aggregate operations
-    //
-
-    fn sum<I: Iterator<Item = Self::Element>>(&self, mut iter: I) -> Self::Element {
-        let mut acc = iter.next().unwrap_or(self.zero());
-        for x in iter {
-            self.add_assign(&mut acc, &x)
-        }
-        acc
-    }
-
-    fn sum_refs<'a, I: Iterator<Item = &'a Self::Element> + 'a>(
-        &self,
-        mut iter: I,
-    ) -> Self::Element {
-        let mut acc = iter.next().cloned().unwrap_or(self.zero());
-        for x in iter {
-            self.add_assign(&mut acc, x)
-        }
-        acc
-    }
-
-    fn product<I: Iterator<Item = Self::Element>>(&self, mut iter: I) -> Self::Element {
-        let mut acc = iter.next().unwrap_or(self.one());
-        for x in iter {
-            self.mul_assign(&mut acc, &x)
-        }
-        acc
-    }
-
-    fn product_refs<'a, I: Iterator<Item = &'a Self::Element>>(
-        &self,
-        mut iter: I,
-    ) -> Self::Element {
-        let mut acc = iter.next().cloned().unwrap_or(self.one());
-        for x in iter {
-            self.mul_assign(&mut acc, x)
-        }
-        acc
-    }
 }
 
-/// Element of an integer field modulo prime number (F_p).
+/// Configuration of an integer field modulo prime number (F_p).
 /// Prime modulus might be dynamic and can be determined at runtime.
 ///
 /// When performing arithmetic operations, the modulus of both operands must be
 /// the same, otherwise outcome is undefined.
-///
-/// Fixed/constant prime fields are considered a special case of dynamic prime
-/// fields, and the bridge struct is [`FixedFieldConfig`].
 ///
 /// For base fields (and only for them), [`WithAssociatedInteger::Integer`]
 /// additionally serves as the modulus type and the target of `LiftElement*`.
 pub trait BaseFieldConfig:
     Sized
     + FieldConfig
-    + LiftElementDynamic<<Self as WithAssociatedInteger>::Integer>
-    + ProjectElementDynamic<<Self as WithAssociatedInteger>::Integer>
+    + LiftElementWithConfig<<Self as WithAssociatedInteger>::Integer>
+    + ProjectElementWithConfig<<Self as WithAssociatedInteger>::Integer>
 {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError>;
 
@@ -306,69 +229,19 @@ pub trait BaseFieldConfig:
     fn modulus_minus_one_div_two(&self) -> Self::Integer;
 }
 
-/// [`BaseFieldConfig`] implementation for fixed fields.
-/// It delegates operations to the field, and `new` checks if the modulus
-/// matches the static one.
-///
-/// Use [`Default::default`] to get a usable instance.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
-pub struct FixedFieldConfig<F: FixedField>(PhantomData<F>);
-
-impl<F: FixedField> FieldConfig for FixedFieldConfig<F> {
-    type Element = F;
-
-    #[inline(always)]
-    fn is_zero(&self, value: &Self::Element) -> bool {
-        value.is_zero()
-    }
-
-    #[inline(always)]
-    fn zero(&self) -> Self::Element {
-        F::zero()
-    }
-
-    #[inline(always)]
-    fn one(&self) -> Self::Element {
-        F::one()
-    }
-
-    #[inline(always)]
-    fn neg(&self, x: &Self::Element) -> Self::Element {
-        x.clone().neg()
-    }
-
-    #[inline(always)]
-    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
-        x.clone() + y
-    }
-
-    #[inline(always)]
-    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
-        x.clone() - y
-    }
-
+impl<F: Field> FieldConfig for FixedConfig<F> {
     #[inline(always)]
     fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
         x.clone().inv()
     }
 
     #[inline(always)]
-    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
-        x.clone() * y
-    }
-
-    #[inline(always)]
     fn pow(&self, x: &Self::Element, y: &F::Integer) -> Self::Element {
-        x.clone().pow(y)
-    }
-
-    #[inline(always)]
-    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
         x.clone().pow(y)
     }
 }
 
-impl<F: FixedBaseField> BaseFieldConfig for FixedFieldConfig<F> {
+impl<F: BaseField> BaseFieldConfig for FixedConfig<F> {
     /// Usually it makes more sense to use [`Default::default`] to obtain an
     /// instance instead.
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
@@ -390,18 +263,27 @@ impl<F: FixedBaseField> BaseFieldConfig for FixedFieldConfig<F> {
     }
 }
 
-impl<F: FixedField> WithAssociatedInteger for FixedFieldConfig<F> {
+impl<F: SetElement + WithAssociatedInteger> WithAssociatedInteger for FixedConfig<F> {
     type Integer = F::Integer;
 }
 
-impl<F: FixedBaseField> LiftElementDynamic<F::Integer> for FixedFieldConfig<F> {
+impl<F: Field + WithAssociatedInteger + LiftElement<F::Integer>> LiftElementWithConfig<F::Integer>
+    for FixedConfig<F>
+{
     #[inline(always)]
     fn lift(&self, value: &F) -> F::Integer {
-        LiftElementStatic::lift(value)
+        LiftElement::lift(value)
     }
 }
 
-impl<F: FixedBaseField> ProjectElementDynamic<F::Integer> for FixedFieldConfig<F> {
+impl<F: Field> WithExtensionDegree for FixedConfig<F> {
+    #[inline(always)]
+    fn extension_degree() -> u64 {
+        F::extension_degree()
+    }
+}
+
+impl<F: BaseField> ProjectElementWithConfig<F::Integer> for FixedConfig<F> {
     #[inline(always)]
     fn project(&self, value: &F::Integer) -> F {
         F::from(value)
@@ -415,16 +297,16 @@ impl<F: FixedBaseField> ProjectElementDynamic<F::Integer> for FixedFieldConfig<F
 pub trait WithAssociatedInteger {
     /// The exponent/order domain of this field: an integer semiring type wide
     /// enough to hold the exponents the field cares about (up to its order).
-    type Integer: Semiring;
+    type Integer: IntSemiring;
 }
 
 //
 // LiftElement
 //
 
-/// Lifts the field element to a specified type, applicable for fixed fields
-/// where this can be done on the element itself.
-pub trait LiftElementStatic<T> {
+/// Lifts the field element to a specified type, applicable for self-sufficient
+/// fields where this can be done on the element itself.
+pub trait LiftElement<T> {
     /// Lift the field element to a specified type using a natural approach.
     ///
     /// Can be projected back to the field using [`From`] to get the same
@@ -433,12 +315,12 @@ pub trait LiftElementStatic<T> {
 }
 
 /// Lifts the field element to a specified type, applicable for
-/// general/dynamic fields where this requires a [`FieldConfig`] to work.
-pub trait LiftElementDynamic<T>: FieldConfig {
+/// general/dynamic fields where this requires a [`SetConfig`] to work.
+pub trait LiftElementWithConfig<T>: SetConfig {
     /// Lift the field element to a specified type using a natural approach.
     ///
     /// Can be projected back to the field using
-    /// [`ProjectElementDynamic::project`] to get the same field element.
+    /// [`ProjectElementWithConfig::project`] to get the same field element.
     fn lift(&self, value: &Self::Element) -> T;
 }
 
@@ -446,54 +328,43 @@ pub trait LiftElementDynamic<T>: FieldConfig {
 // ProjectElement
 //
 
-/// Converts a given value to a field element of a current field.
+/// Converts a given value to an element of the current field.
 ///
 /// Static counterpart of this trait is just [`From`].
-pub trait ProjectElementDynamic<T>: FieldConfig {
+pub trait ProjectElementWithConfig<T>: SetConfig {
     fn project(&self, value: &T) -> Self::Element;
 }
 
-/// Trivial implementation for fixed fields and types that implement `From<T>`.
-impl<F, T> ProjectElementDynamic<T> for F
-where
-    F: FieldConfig + FixedBaseField,
-    F::Element: for<'a> From<&'a T>,
-{
-    fn project(&self, value: &T) -> F::Element {
-        F::Element::from(value)
-    }
-}
-
-/// The trait combines all `ProjectElement<u*>` and `ProjectElement<i*>` into
-/// one umbrella trait. Handy when one needs conversion functions for different
-/// primitive int types.
-pub trait ProjectPrimitiveIntegersDynamic:
-    ProjectElementDynamic<u8>
-    + ProjectElementDynamic<u16>
-    + ProjectElementDynamic<u32>
-    + ProjectElementDynamic<u64>
-    + ProjectElementDynamic<u128>
-    + ProjectElementDynamic<i8>
-    + ProjectElementDynamic<i16>
-    + ProjectElementDynamic<i32>
-    + ProjectElementDynamic<i64>
-    + ProjectElementDynamic<i128>
+/// The trait combines all `ProjectElementWithConfig<u*>` and
+/// `ProjectElementWithConfig<i*>` into one umbrella trait. Handy when one needs
+/// conversion functions for different primitive int types.
+pub trait ProjectPrimitiveIntegersWithConfig:
+    ProjectElementWithConfig<u8>
+    + ProjectElementWithConfig<u16>
+    + ProjectElementWithConfig<u32>
+    + ProjectElementWithConfig<u64>
+    + ProjectElementWithConfig<u128>
+    + ProjectElementWithConfig<i8>
+    + ProjectElementWithConfig<i16>
+    + ProjectElementWithConfig<i32>
+    + ProjectElementWithConfig<i64>
+    + ProjectElementWithConfig<i128>
 {
 }
 
 /// Blanket implementation.
 impl<
-    T: ProjectElementDynamic<u8>
-        + ProjectElementDynamic<u16>
-        + ProjectElementDynamic<u32>
-        + ProjectElementDynamic<u64>
-        + ProjectElementDynamic<u128>
-        + ProjectElementDynamic<i8>
-        + ProjectElementDynamic<i16>
-        + ProjectElementDynamic<i32>
-        + ProjectElementDynamic<i64>
-        + ProjectElementDynamic<i128>,
-> ProjectPrimitiveIntegersDynamic for T
+    T: ProjectElementWithConfig<u8>
+        + ProjectElementWithConfig<u16>
+        + ProjectElementWithConfig<u32>
+        + ProjectElementWithConfig<u64>
+        + ProjectElementWithConfig<u128>
+        + ProjectElementWithConfig<i8>
+        + ProjectElementWithConfig<i16>
+        + ProjectElementWithConfig<i32>
+        + ProjectElementWithConfig<i64>
+        + ProjectElementWithConfig<i128>,
+> ProjectPrimitiveIntegersWithConfig for T
 {
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -44,8 +44,6 @@ pub mod crypto_bigint_boxed_monty;
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_const_monty;
 #[cfg(feature = "crypto_bigint")]
-pub(crate) mod crypto_bigint_helpers;
-#[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_monty;
 pub mod f2;
 
@@ -58,11 +56,6 @@ use core::{
 use num_traits::{Inv, Pow, Zero};
 use pastey::paste;
 use thiserror::Error;
-
-#[cfg(target_pointer_width = "64")]
-pub const WORD_FACTOR: usize = 1;
-#[cfg(target_pointer_width = "32")]
-pub const WORD_FACTOR: usize = 2;
 
 //
 // FixedField (static and const)

--- a/src/field.rs
+++ b/src/field.rs
@@ -42,7 +42,7 @@ pub mod f2;
 
 use crate::{
     ConstRing, FixedConfig, IntSemiring, Ring, RingConfig, SemiringConfig, SetConfig, SetElement,
-    delegate_to_ref_binary,
+    helpers::{define_blanket_trait, delegate_to_ref_binary},
 };
 use core::{
     fmt::Debug,
@@ -56,29 +56,29 @@ use thiserror::Error;
 // Field (static and const)
 //
 
-/// See [module-level documentation](crate::field).
-///
-/// This is a general trait for all fields, [base](BaseField) and extension.
-pub trait Field:
-    SetElement
-    + Ring
-    + WithAssociatedInteger
-    + WithExtensionDegree
-    + Inv<Output = Option<Self>>
-    // Arithmetic operations consuming rhs
-    + Pow<Self::Integer, Output=Self>
-    + Div<Output=Self>
-    + DivAssign
-    // Arithmetic operations with rhs reference
-    + for<'a> Pow<&'a Self::Integer, Output=Self>
-    + for<'a> Div<&'a Self, Output=Self>
-    + for<'a> DivAssign<&'a Self>
-    // Conversion
-    + From<u64>
-    + From<u128>
-    + From<Self::Integer>
-    + for<'a> From<&'a Self::Integer>
-{
+define_blanket_trait! {
+    /// See [module-level documentation](crate::field).
+    ///
+    /// This is a general trait for all fields, [base](BaseField) and extension.
+    pub trait Field:
+        SetElement
+        + Ring
+        + WithAssociatedInteger
+        + WithExtensionDegree
+        + Inv<Output = Option<Self>>
+        // Arithmetic operations consuming rhs
+        + Pow<Self::Integer, Output=Self>
+        + Div<Output=Self>
+        + DivAssign
+        // Arithmetic operations with rhs reference
+        + for<'a> Pow<&'a Self::Integer, Output=Self>
+        + for<'a> Div<&'a Self, Output=Self>
+        + for<'a> DivAssign<&'a Self>
+        // Conversion
+        + From<u64>
+        + From<u128>
+        + From<Self::Integer>
+        + for<'a> From<&'a Self::Integer>
 }
 
 /// The field's degree over its prime subfield; 1 for base fields.
@@ -91,31 +91,10 @@ pub trait WithExtensionDegree {
     fn extension_degree() -> u64;
 }
 
-impl<T> Field for T where
-    T: SetElement
-        + Ring
-        + WithAssociatedInteger
-        + WithExtensionDegree
-        + Inv<Output = Option<Self>>
-        // Arithmetic operations consuming rhs
-        + Pow<Self::Integer, Output = Self>
-        + Div<Output = Self>
-        + DivAssign
-        // Arithmetic operations with rhs reference
-        + for<'a> Pow<&'a Self::Integer, Output = Self>
-        + for<'a> Div<&'a Self, Output = Self>
-        + for<'a> DivAssign<&'a Self>
-        // Conversion
-        + From<u64>
-        + From<u128>
-        + From<Self::Integer>
-        + for<'a> From<&'a Self::Integer>
-{
+define_blanket_trait! {
+    /// [`Field`] with a bunch of values known at compile time.
+    pub trait ConstField: Field + ConstRing
 }
-
-/// [`Field`] with a bunch of values known at compile time.
-pub trait ConstField: Field + ConstRing {}
-impl<F: Field + ConstRing> ConstField for F {}
 
 /// Base (non-extension) prime field with elements being self-sufficient, but
 /// whose metadata like modulus is not necessarily known at compile-time.
@@ -342,26 +321,12 @@ pub trait ProjectElementWithConfig<T>: SetConfig {
     fn project(&self, value: &T) -> Self::Element;
 }
 
-/// The trait combines all `ProjectElementWithConfig<u*>` and
-/// `ProjectElementWithConfig<i*>` into one umbrella trait. Handy when one needs
-/// conversion functions for different primitive int types.
-pub trait ProjectPrimitiveIntegersWithConfig:
-    ProjectElementWithConfig<u8>
-    + ProjectElementWithConfig<u16>
-    + ProjectElementWithConfig<u32>
-    + ProjectElementWithConfig<u64>
-    + ProjectElementWithConfig<u128>
-    + ProjectElementWithConfig<i8>
-    + ProjectElementWithConfig<i16>
-    + ProjectElementWithConfig<i32>
-    + ProjectElementWithConfig<i64>
-    + ProjectElementWithConfig<i128>
-{
-}
-
-/// Blanket implementation.
-impl<
-    T: ProjectElementWithConfig<u8>
+define_blanket_trait! {
+    /// The trait combines all `ProjectElementWithConfig<u*>` and
+    /// `ProjectElementWithConfig<i*>` into one umbrella trait. Handy when one needs
+    /// conversion functions for different primitive int types.
+    pub trait ProjectPrimitiveIntegersWithConfig:
+        ProjectElementWithConfig<u8>
         + ProjectElementWithConfig<u16>
         + ProjectElementWithConfig<u32>
         + ProjectElementWithConfig<u64>
@@ -370,9 +335,7 @@ impl<
         + ProjectElementWithConfig<i16>
         + ProjectElementWithConfig<i32>
         + ProjectElementWithConfig<i64>
-        + ProjectElementWithConfig<i128>,
-> ProjectPrimitiveIntegersWithConfig for T
-{
+        + ProjectElementWithConfig<i128>
 }
 
 //

--- a/src/field.rs
+++ b/src/field.rs
@@ -60,6 +60,7 @@ pub trait FixedField:
 pub trait FixedBaseField: FixedField + LiftToIntegerStatic {
     fn modulus() -> Self::Integer;
 
+    /// (mod - 1) / 2
     fn modulus_minus_one_div_two() -> Self::Integer;
 }
 
@@ -67,6 +68,8 @@ pub trait FixedBaseField: FixedField + LiftToIntegerStatic {
 /// constant values known at compile time.
 pub trait ConstBaseField: FixedField + LiftToIntegerStatic + ConstRing {
     const MODULUS: Self::Integer;
+
+    /// (mod - 1) / 2
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;
 }
 
@@ -248,32 +251,36 @@ pub trait FieldConfigOps: WithAssociatedInteger {
 /// Prime modulus might be dynamic and can be determined at runtime.
 ///
 /// When performing arithmetic operations, the modulus of both operands must be
-/// the same, otherwise operations should panic in debug mode.
+/// the same, otherwise outcome is undefined.
 ///
-/// Constant prime fields are considered a special case of dynamic prime fields.
-pub trait FieldConfig:
+/// Fixed/constant prime fields are considered a special case of dynamic prime
+/// fields, and the bridge struct is [`FixedFieldConfig`].
+///
+/// For base fields (and only for them), [`Self::Integer`] additionally serves
+/// as the modulus type and the target of `LiftToInteger*`.
+pub trait BaseFieldConfig:
     Sized
-    + WithAssociatedInteger
     + FieldConfigOps
+    + LiftToIntegerDynamic
     + ProjectElement<<Self as WithAssociatedInteger>::Integer>
 {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError>;
 
     fn modulus(&self) -> Self::Integer;
 
+    /// (mod - 1) / 2
     fn modulus_minus_one_div_two(&self) -> Self::Integer;
 }
 
-/// [`FieldConfig`] implementation for fixed fields.
+/// [`BaseFieldConfig`] implementation for fixed fields.
 /// It delegates operations to the field, and `new` checks if the modulus
 /// matches the static one.
-#[derive(Clone, Copy, Default, Debug)]
-pub struct FixedFieldConfig<F: FixedBaseField>(PhantomData<F>);
+///
+/// Use [`Default::default`] to get a usable instance.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+pub struct FixedFieldConfig<F: FixedField>(PhantomData<F>);
 
-impl<F> FieldConfigOps for FixedFieldConfig<F>
-where
-    F: FixedBaseField + LiftToIntegerStatic,
-{
+impl<F: FixedField> FieldConfigOps for FixedFieldConfig<F> {
     type Element = F;
 
     #[inline(always)]
@@ -327,10 +334,9 @@ where
     }
 }
 
-impl<F> FieldConfig for FixedFieldConfig<F>
-where
-    F: FixedBaseField + LiftToIntegerStatic,
-{
+impl<F: FixedBaseField> BaseFieldConfig for FixedFieldConfig<F> {
+    /// Usually it makes more sense to use [`Default::default`] to obtain an
+    /// instance instead.
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
         if *modulus == F::modulus() {
             Ok(Self::default())
@@ -350,7 +356,7 @@ where
     }
 }
 
-impl<F: FixedBaseField> WithAssociatedInteger for FixedFieldConfig<F> {
+impl<F: FixedField> WithAssociatedInteger for FixedFieldConfig<F> {
     type Integer = F::Integer;
 }
 
@@ -374,29 +380,38 @@ where
 }
 
 //
-// LiftToInteger
+// WithAssociatedInteger/LiftToInteger
 //
 
 pub trait WithAssociatedInteger {
-    /// A semiring integer type that's used to represent the value of this field
-    /// when lifted to integers. Also used to represent modulus in prime
-    /// fields.
+    /// The exponent/order domain of this field: an integer semiring type wide
+    /// enough to hold the exponents the field cares about (up to its order).
+    ///
+    ///
+    /// Note: this type is deliberately NOT the "modulus/lift" type in general
+    /// (an extension field would lift to a polynomial, not to an integer).
+    /// Only for base (prime) fields do the two coincide, as guaranteed by
+    /// [`BaseFieldConfig`] and the `LiftToInteger*` traits.
     type Integer: Semiring;
 }
 
+/// Lifts the structure element to an associated integer, applicable for fixed
+/// fields where this can be done on the element itself.
 pub trait LiftToIntegerStatic: WithAssociatedInteger {
     /// Lift the field element to integer semiring using a natural approach.
     ///
     /// Can be projected back to the field using
-    /// [`ProjectElement::encode`] to get the same field element.
+    /// [`ProjectElement::project`] to get the same field element.
     fn lift_to_integer(&self) -> Self::Integer;
 }
 
+/// Lifts the structure element to an associated integer, applicable for
+/// general/dynamic fields where this requres [`BaseFieldConfig`] to work.
 pub trait LiftToIntegerDynamic: WithAssociatedInteger + FieldConfigOps {
     /// Lift the field element to integer semiring using a natural approach.
     ///
     /// Can be projected back to the field using
-    /// [`FromWithConfig::from_with_cfg`] to get the same field element.
+    /// [`ProjectElement::project`] to get the same field element.
     fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer;
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -263,12 +263,16 @@ impl<F: BaseField> BaseFieldConfig for FixedConfig<F> {
     }
 }
 
-impl<F: SetElement + WithAssociatedInteger> WithAssociatedInteger for FixedConfig<F> {
+impl<F> WithAssociatedInteger for FixedConfig<F>
+where
+    F: SetElement + WithAssociatedInteger,
+{
     type Integer = F::Integer;
 }
 
-impl<F: Field + WithAssociatedInteger + LiftElement<F::Integer>> LiftElementWithConfig<F::Integer>
-    for FixedConfig<F>
+impl<F> LiftElementWithConfig<F::Integer> for FixedConfig<F>
+where
+    F: Field + WithAssociatedInteger + LiftElement<F::Integer>,
 {
     #[inline(always)]
     fn lift(&self, value: &F) -> F::Integer {
@@ -283,9 +287,12 @@ impl<F: Field> WithExtensionDegree for FixedConfig<F> {
     }
 }
 
-impl<F: BaseField> ProjectElementWithConfig<F::Integer> for FixedConfig<F> {
+impl<F, T> ProjectElementWithConfig<T> for FixedConfig<F>
+where
+    F: Field + for<'a> From<&'a T>,
+{
     #[inline(always)]
-    fn project(&self, value: &F::Integer) -> F {
+    fn project(&self, value: &T) -> F {
         F::from(value)
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -12,12 +12,16 @@ pub(crate) mod crypto_bigint_helpers;
 pub mod crypto_bigint_monty;
 pub mod f2;
 
-use crate::{ConstSemiring, Semiring, ring::Ring};
+use crate::{
+    ConstRing, ConstSemiring, FixedRing, FixedSemiring, IntRing, IntSemiring, Semiring, ring::Ring,
+};
 use core::{
     fmt::Debug,
+    marker::PhantomData,
     ops::{Div, DivAssign, Neg},
 };
 use num_traits::{Inv, Pow, Zero};
+use pastey::paste;
 use thiserror::Error;
 
 #[cfg(target_pointer_width = "64")]
@@ -25,48 +29,239 @@ pub const WORD_FACTOR: usize = 1;
 #[cfg(target_pointer_width = "32")]
 pub const WORD_FACTOR: usize = 2;
 
+//
+// FixedField (static and const)
+//
+
 /// Element of a field (F) - a group where addition and multiplication are
 /// defined with their respective inverse operations.
-pub trait Field:
-    Ring
-    + Neg<Output=Self>
+pub trait FixedField:
+    FixedRing
+    + WithAssociatedInteger
     + Pow<u32, Output=Self>
+    + Inv<Output = Option<Self>>
     // Arithmetic operations consuming rhs
+    //+ Pow<Self::Integer, Output=Self>
     + Div<Output=Self>
     + DivAssign
     // Arithmetic operations with rhs reference
+    //+ for<'a> Pow<&'a Self::Integer, Output=Self>
     + for<'a> Div<&'a Self, Output=Self>
     + for<'a> DivAssign<&'a Self>
+    // Conversion
+    + From<u64>
+    + From<u128>
+    + From<Self::Integer>
+    + for<'a> From<&'a Self::Integer>
+    + 'static
 {
-    /// A semiring integer type that's used to represent the value of this field when lifted to integers.
-    /// Also used to represent modulus in prime fields.
-    type Integer: Semiring;
-
-    /// Type of the underlying representation of this field element. This type might differ from [`Self::Integer`],
-    /// and is *NOT* guaranteed to be normalized.
-    /// Should only be used to reconstruct the field using [`ConstPrimeField::new_unchecked`] and
-    /// [`PrimeField::new_unchecked_with_cfg`] (with the same config supplied!).
+    /// Type of the underlying representation of this structure.
     type Inner: Debug + Eq + Clone + Sync + Send;
 
+    /// Get a reference to the wrapped value.
     fn inner(&self) -> &Self::Inner;
+
+    /// Get a mutable reference to the wrapped value.
     fn inner_mut(&mut self) -> &mut Self::Inner;
+
+    /// Get the wrapped value, consuming self.
     fn into_inner(self) -> Self::Inner;
 
-    /// Lift the field element to integer semiring using a natural approach.
-    ///
-    /// Can be projected back to the field using [`FromWithConfig::from_with_cfg`] to get the same field element.
-    fn lift_to_integer(&self) -> Self::Integer;
+    /// Creates a new instance of this structure from a representation
+    /// known to be valid - should consume exactly the value returned by
+    /// `inner()`. Ideally, this should not check the validity of the
+    /// element, but it's acceptable to perform a check if it can't be
+    /// avoided.
+    fn new_unchecked(inner: Self::Inner) -> Self;
 }
 
-/// A helper supertrait for prime fields, allows decoupling of
-/// [`FromWithConfig`].
-pub trait HasPrimeFieldConfig {
-    /// Runtime configuration for the prime field, empty for constant prime
-    /// fields. For dynamic prime fields, it could be just modulus or more
-    /// complex structure.
-    type Config: Debug + Clone + Send + Sync + 'static;
+/// Base (non-extension) prime field with elements being self-sufficient, but
+/// whose metadata like modulus is not necessarily known at compile-time.
+pub trait FixedBaseField: FixedField {
+    fn modulus() -> Self::Integer;
 
-    fn cfg(&self) -> &Self::Config;
+    fn modulus_minus_one_div_two() -> Self::Integer;
+}
+
+/// Base (non-extension) prime field whose modulus and other metadata are
+/// constant values known at compile time.
+pub trait ConstBaseField: FixedField + ConstRing {
+    const MODULUS: Self::Integer;
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;
+}
+
+impl<T: ConstBaseField> FixedBaseField for T {
+    fn modulus() -> Self::Integer {
+        Self::MODULUS
+    }
+
+    fn modulus_minus_one_div_two() -> Self::Integer {
+        Self::MODULUS_MINUS_ONE_DIV_TWO
+    }
+}
+
+impl<F: FixedField + IntSemiring> IntRing for F {
+    #[inline(always)]
+    fn checked_abs(&self) -> Option<Self> {
+        Some(self.clone())
+    }
+
+    #[inline(always)]
+    fn is_positive(&self) -> bool {
+        !self.is_zero()
+    }
+
+    #[inline(always)]
+    fn is_negative(&self) -> bool {
+        false
+    }
+}
+
+macro_rules! delegate_to_ref_binary {
+    ($(#[$attr:meta])* $op:ident) => {
+        delegate_to_ref_binary!($(#[$attr])* $op(&Self::Element));
+    };
+    ($(#[$attr:meta])* $op:ident($rhs_type:ty)) => {
+        paste! {
+            $(#[$attr])*
+            fn [<$op _assign>](&self, x: &mut Self::Element, y: $rhs_type) {
+                *x = self.$op(x, y);
+            }
+        }
+    };
+}
+
+//
+// FieldConfig (both static and dynamic)
+//
+
+pub trait FieldConfigOps {
+    type Element: Debug + Eq + Clone + Send + Sync + 'static;
+
+    fn is_zero(&self, value: &Self::Element) -> bool;
+
+    fn zero(&self) -> Self::Element;
+
+    fn one(&self) -> Self::Element;
+
+    //
+    // Operations on refs
+    //
+
+    /// -x
+    fn neg(&self, x: &Self::Element) -> Self::Element;
+
+    /// x + y
+    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
+
+    /// x - y
+    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
+
+    /// 1/x
+    fn inv(&self, x: &Self::Element) -> Option<Self::Element>;
+
+    /// x * y
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
+
+    /// x / y
+    fn div(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        self.checked_div(x, y).expect("Division by zero")
+    }
+
+    /// x / y
+    ///
+    /// (Note: Field operations do not overflow)
+    #[inline(always)]
+    fn checked_div(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.mul(x, &self.inv(y)?))
+    }
+
+    /// x ** y
+    fn pow(&self, x: &Self::Element, y: &Self::Element) -> Self::Element { todo!() }
+
+    /// x ** y
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element;
+
+    //
+    // Operations on mutable refs
+    //
+
+    // x = -x;
+    fn neg_assign(&self, x: &mut Self::Element) {
+        *x = self.neg(x);
+    }
+
+    delegate_to_ref_binary! {
+        /// x += y
+        add
+    }
+
+    delegate_to_ref_binary! {
+        /// x -= y
+        sub
+    }
+
+    delegate_to_ref_binary! {
+        /// x *= y
+        mul
+    }
+
+    delegate_to_ref_binary! {
+        /// x /= y
+        div
+    }
+
+    delegate_to_ref_binary! {
+        /// x **= y
+        pow
+    }
+
+    delegate_to_ref_binary! {
+        /// x **= y
+        pow_u32(u32)
+    }
+
+    //
+    // Aggregate operations
+    //
+
+    fn sum<I: Iterator<Item = Self::Element>>(&self, mut iter: I) -> Self::Element {
+        let mut acc = iter.next().unwrap_or(self.zero());
+        for x in iter {
+            self.add_assign(&mut acc, &x)
+        }
+        acc
+    }
+
+    fn sum_refs<'a, I: Iterator<Item = &'a Self::Element> + 'a>(
+        &self,
+        mut iter: I,
+    ) -> Self::Element {
+        let mut acc = iter.next().cloned().unwrap_or(self.zero());
+        for x in iter {
+            self.add_assign(&mut acc, x)
+        }
+        acc
+    }
+
+    fn product<I: Iterator<Item = Self::Element>>(&self, mut iter: I) -> Self::Element {
+        let mut acc = iter.next().unwrap_or(self.one());
+        for x in iter {
+            self.mul_assign(&mut acc, &x)
+        }
+        acc
+    }
+
+    fn product_refs<'a, I: Iterator<Item = &'a Self::Element>>(
+        &self,
+        mut iter: I,
+    ) -> Self::Element {
+        let mut acc = iter.next().cloned().unwrap_or(self.one());
+        for x in iter {
+            self.mul_assign(&mut acc, x)
+        }
+        acc
+    }
 }
 
 /// Element of an integer field modulo prime number (F_p).
@@ -76,176 +271,192 @@ pub trait HasPrimeFieldConfig {
 /// the same, otherwise operations should panic in debug mode.
 ///
 /// Constant prime fields are considered a special case of dynamic prime fields.
-pub trait PrimeField:
-    Field
-    + HasPrimeFieldConfig
-    + FromWithConfig<Self::Integer>
-    + for<'a> FromWithConfig<&'a Self::Integer>
+pub trait FieldConfig:
+    Sized + FieldConfigOps + WithAssociatedInteger + ProjectElement<Self::Integer>
 {
-    fn modulus(cfg: &Self::Config) -> Self::Integer;
+    fn new(modulus: &Self::Integer) -> Result<Self, FieldError>;
 
-    fn modulus_minus_one_div_two(cfg: &Self::Config) -> Self::Integer;
+    fn modulus(&self) -> Self::Integer;
 
-    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError>;
-
-    /// Creates a new instance of the prime field element from a representation
-    /// known to be valid - should consume exactly the value returned by
-    /// [`Self::inner()`]. Ideally, this should not check the validity of the
-    /// element, but it's acceptable to perform a check if it can't be
-    /// avoided.
-    fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self;
-
-    // Note: Not using `&self` to avoid conflicts with `Zero` trait.
-    fn is_zero(value: &Self) -> bool;
-
-    fn zero_with_cfg(cfg: &Self::Config) -> Self;
-
-    fn one_with_cfg(cfg: &Self::Config) -> Self;
+    fn modulus_minus_one_div_two(&self) -> Self::Integer;
 }
 
-/// Prime field whose modulus is a constant value known at compile time.
-pub trait ConstPrimeField:
-    Field
-    + ConstSemiring
-    + Inv<Output = Option<Self>>
-    + From<u64>
-    + From<u128>
-    + From<Self::Inner>
-    + From<Self::Integer>
-    + for<'a> From<&'a Self::Integer>
-{
-    const MODULUS: Self::Integer;
-    const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer;
+/// [`FieldConfig`] implementation for fixed fields.
+/// It delegates operations to the field, and `new` checks if the modulus
+/// matches the static one.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct FixedFieldConfig<F: FixedBaseField>(PhantomData<F>);
 
-    /// Creates a new instance of the prime field element from a representation
-    /// known to be valid - should consume exactly the value returned by
-    /// `inner()`. Ideally, this should not check the validity of the
-    /// element, but it's acceptable to perform a check if it can't be
-    /// avoided.
-    fn new_unchecked(inner: Self::Inner) -> Self;
-}
+impl<F: FixedBaseField> FieldConfigOps for FixedFieldConfig<F> {
+    type Element = F;
 
-impl<T: ConstPrimeField> HasPrimeFieldConfig for T {
-    /// For constant prime fields, the configuration is empty.
-    type Config = ();
-
-    fn cfg(&self) -> &Self::Config {
-        &()
-    }
-}
-
-impl<T: ConstPrimeField> PrimeField for T {
     #[inline(always)]
-    fn modulus(_cfg: &Self::Config) -> Self::Integer {
-        Self::MODULUS
+    fn is_zero(&self, value: &Self::Element) -> bool {
+        value.is_zero()
     }
 
     #[inline(always)]
-    fn modulus_minus_one_div_two(_cfg: &Self::Config) -> Self::Integer {
-        Self::MODULUS_MINUS_ONE_DIV_TWO
+    fn zero(&self) -> Self::Element {
+        F::zero()
     }
 
-    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
-        if *modulus == Self::MODULUS {
-            Ok(())
+    #[inline(always)]
+    fn one(&self) -> Self::Element {
+        F::one()
+    }
+
+    #[inline(always)]
+    fn neg(&self, x: &Self::Element) -> Self::Element {
+        x.clone().neg()
+    }
+
+    #[inline(always)]
+    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.clone() + y
+    }
+
+    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.clone() - y
+    }
+
+    fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
+        x.clone().inv()
+    }
+
+    #[inline(always)]
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.clone() * y
+    }
+
+    fn pow(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        todo!() //x.clone().pow(y)
+    }
+
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
+        x.clone().pow(y)
+    }
+}
+
+impl<F: FixedBaseField> FieldConfig for FixedFieldConfig<F> {
+    fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
+        if *modulus == F::modulus() {
+            Ok(Self::default())
         } else {
             Err(FieldError::InvalidModulus)
         }
     }
 
     #[inline(always)]
-    fn new_unchecked_with_cfg(inner: Self::Inner, _cfg: &Self::Config) -> Self {
-        ConstPrimeField::new_unchecked(inner)
+    fn modulus(&self) -> Self::Integer {
+        F::modulus()
     }
 
     #[inline(always)]
-    fn is_zero(value: &Self) -> bool {
-        Zero::is_zero(value)
+    fn modulus_minus_one_div_two(&self) -> Self::Integer {
+        F::modulus_minus_one_div_two()
     }
+}
 
+impl<F: FixedBaseField> WithAssociatedInteger for FixedFieldConfig<F> {
+    type Integer = F::Integer;
+}
+
+impl<F: FixedBaseField + LiftToIntegerStatic> LiftToIntegerDynamic for FixedFieldConfig<F> {
     #[inline(always)]
-    fn zero_with_cfg(_cfg: &Self::Config) -> Self {
-        Self::ZERO
-    }
-
-    #[inline(always)]
-    fn one_with_cfg(_cfg: &Self::Config) -> Self {
-        Self::ONE
+    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
+        LiftToIntegerStatic::lift_to_integer(value)
     }
 }
 
-/// Element of a prime field in its Montgomery representation of - encoded in a
-/// way so that modular multiplication can be done without performing an
-/// explicit division by pp after each product.
-pub trait MontgomeryField: PrimeField {
-    // FIXME
-
-    /// INV = -MODULUS^{-1} mod R
-    const INV: Self::Inner;
+impl<F: FixedBaseField> ProjectElement<F::Integer> for FixedFieldConfig<F> {
+    fn project(&self, value: &F::Integer) -> Self::Element {
+        F::from(value)
+    }
 }
 
-/// Analogous to `From` trait, but with a prime field configuration parameter.
-pub trait FromWithConfig<T>: HasPrimeFieldConfig {
-    fn from_with_cfg(value: T, cfg: &Self::Config) -> Self;
+//
+// LiftToInteger
+//
+
+pub trait WithAssociatedInteger {
+    /// A semiring integer type that's used to represent the value of this field
+    /// when lifted to integers. Also used to represent modulus in prime
+    /// fields.
+    type Integer: Semiring;
 }
 
-/// Trivial implementation for types that implement `From<T>`.
-impl<F, T> FromWithConfig<T> for F
+pub trait LiftToIntegerStatic: WithAssociatedInteger {
+    /// Lift the field element to integer semiring using a natural approach.
+    ///
+    /// Can be projected back to the field using
+    /// [`ProjectElement::encode`] to get the same field element.
+    fn lift_to_integer(&self) -> Self::Integer;
+}
+
+pub trait LiftToIntegerDynamic: WithAssociatedInteger + FieldConfigOps {
+    /// Lift the field element to integer semiring using a natural approach.
+    ///
+    /// Can be projected back to the field using
+    /// [`FromWithConfig::from_with_cfg`] to get the same field element.
+    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer;
+}
+
+//
+// ProjectElement
+//
+
+/// Converts a given value to a field element of a current field.
+pub trait ProjectElement<T>: FieldConfigOps {
+    fn project(&self, value: &T) -> Self::Element;
+}
+
+/// Trivial implementation for fixed fields and types that implement `From<T>`.
+impl<F, T> ProjectElement<T> for F
 where
-    F: PrimeField + From<T>,
+    F: FieldConfigOps + FixedBaseField,
+    F::Element: for<'a> From<&'a T>,
 {
-    fn from_with_cfg(value: T, _cfg: &Self::Config) -> Self {
-        Self::from(value)
+    fn project(&self, value: &T) -> F::Element {
+        F::Element::from(value)
     }
 }
 
-/// The trait combines all `FromWithConfig<u*>` and `FromWithConfig<i*>` into
+/// The trait combines all `ProjectElement<u*>` and `ProjectElement<i*>` into
 /// one umbrella trait. Handy when one needs conversion functions for different
 /// primitive int types.
-pub trait FromPrimitiveWithConfig:
-    FromWithConfig<u8>
-    + FromWithConfig<u16>
-    + FromWithConfig<u32>
-    + FromWithConfig<u64>
-    + FromWithConfig<u128>
-    + FromWithConfig<i8>
-    + FromWithConfig<i16>
-    + FromWithConfig<i32>
-    + FromWithConfig<i64>
-    + FromWithConfig<i128>
+pub trait ProjectPrimitiveIntegers:
+    ProjectElement<u8>
+    + ProjectElement<u16>
+    + ProjectElement<u32>
+    + ProjectElement<u64>
+    + ProjectElement<u128>
+    + ProjectElement<i8>
+    + ProjectElement<i16>
+    + ProjectElement<i32>
+    + ProjectElement<i64>
+    + ProjectElement<i128>
 {
 }
 
 /// Blanket implementation.
 impl<
-    T: FromWithConfig<u8>
-        + FromWithConfig<u16>
-        + FromWithConfig<u32>
-        + FromWithConfig<u64>
-        + FromWithConfig<u128>
-        + FromWithConfig<i8>
-        + FromWithConfig<i16>
-        + FromWithConfig<i32>
-        + FromWithConfig<i64>
-        + FromWithConfig<i128>,
-> FromPrimitiveWithConfig for T
+    T: ProjectElement<u8>
+        + ProjectElement<u16>
+        + ProjectElement<u32>
+        + ProjectElement<u64>
+        + ProjectElement<u128>
+        + ProjectElement<i8>
+        + ProjectElement<i16>
+        + ProjectElement<i32>
+        + ProjectElement<i64>
+        + ProjectElement<i128>,
+> ProjectPrimitiveIntegers for T
 {
 }
 
-/// Analogous to `Into` trait, but with a prime field configuration parameter.
-/// Preferably should not be implemented directly.
-pub trait IntoWithConfig<F: PrimeField> {
-    fn into_with_cfg(self, cfg: &F::Config) -> F;
-}
-
-impl<F, T> IntoWithConfig<F> for T
-where
-    F: PrimeField + FromWithConfig<T>,
-{
-    fn into_with_cfg(self, cfg: &F::Config) -> F {
-        F::from_with_cfg(self, cfg)
-    }
-}
+//
+// Errors
+//
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FieldError {

--- a/src/field.rs
+++ b/src/field.rs
@@ -12,9 +12,7 @@ pub(crate) mod crypto_bigint_helpers;
 pub mod crypto_bigint_monty;
 pub mod f2;
 
-use crate::{
-    ConstRing, ConstSemiring, FixedRing, FixedSemiring, IntRing, IntSemiring, Semiring, ring::Ring,
-};
+use crate::{ConstRing, ConstSemiring, FixedRing, IntRing, IntSemiring, Semiring, ring::Ring};
 use core::{
     fmt::Debug,
     marker::PhantomData,

--- a/src/field.rs
+++ b/src/field.rs
@@ -55,24 +55,6 @@ pub trait FixedField:
     + for<'a> From<&'a Self::Integer>
     + 'static
 {
-    /// Type of the underlying representation of this structure.
-    type Inner: Debug + Eq + Clone + Sync + Send;
-
-    /// Get a reference to the wrapped value.
-    fn inner(&self) -> &Self::Inner;
-
-    /// Get a mutable reference to the wrapped value.
-    fn inner_mut(&mut self) -> &mut Self::Inner;
-
-    /// Get the wrapped value, consuming self.
-    fn into_inner(self) -> Self::Inner;
-
-    /// Creates a new instance of this structure from a representation
-    /// known to be valid - should consume exactly the value returned by
-    /// `inner()`. Ideally, this should not check the validity of the
-    /// element, but it's acceptable to perform a check if it can't be
-    /// avoided.
-    fn new_unchecked(inner: Self::Inner) -> Self;
 }
 
 /// Base (non-extension) prime field with elements being self-sufficient, but
@@ -272,7 +254,10 @@ pub trait FieldConfigOps: WithAssociatedInteger {
 ///
 /// Constant prime fields are considered a special case of dynamic prime fields.
 pub trait FieldConfig:
-    Sized + WithAssociatedInteger + FieldConfigOps + ProjectElement<<Self as WithAssociatedInteger>::Integer>
+    Sized
+    + WithAssociatedInteger
+    + FieldConfigOps
+    + ProjectElement<<Self as WithAssociatedInteger>::Integer>
 {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError>;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,3 +1,40 @@
+//! This module defines **fields** - sets where addition and
+//! multiplication are defined with their respective inverse operations.
+//! Supports both static and dynamic fields (via general [`FieldConfig`]).
+//!
+//! Currently, this only defines **base** (non-extension) prime fields, whose
+//! modulus is an integer, but can be seamlessly extended to support extension
+//! fields in the future as well.
+//!
+//! - [`FixedField`] and [`ConstField`] are fields where each element is
+//!   self-sufficient. Instances carry around all metadata necessary to perform
+//!   operations, so they can be used normally as e.g. `a + b`. Every
+//!   [`ConstField`] is a [`FixedField`] as well.
+//!
+//! - [`FieldConfig`] is a field configuration that carries the metadata needed
+//!   to perform operations that the elements themselves do not carry, e.g. a
+//!   modulus only available at runtime. It's used as `f.add(&a, &b)`. Bridge
+//!   between this and [`FixedField`] is [`FixedFieldConfig`].
+//!
+//! - [`WithAssociatedInteger`] is a trait that defines the associated integer
+//!   type for a field, which is used for exponents and order, as well as the
+//!   modulus for base fields.
+//!
+//! - [`LiftElementDynamic`] and [`ProjectElementDynamic`] define how to lift a
+//!   field element to a chosen type and project it back, for a general
+//!   [`FieldConfig`]; base fields lift to their associated integer type (see
+//!   [`BaseFieldConfig`]).
+//!
+//! - Lift/project counterpart for fixed fields is asymmetric - lifting is done
+//!   via [`LiftElementStatic`] (by reference, avoiding a copy of the element)
+//!   while projection is done with [`From`] (both by reference and by value),
+//!   e.g. `F::from(f.lift()) == f`.
+//!
+//! - Base field variants of fields are [`FixedBaseField`], [`ConstBaseField`]
+//!   and [`BaseFieldConfig`]. They additionally allow lifting elements to the
+//!   associated integer type (and, on the config side, projecting from it).
+//!   They also define an integer `modulus`.
+
 #[cfg(feature = "ark_ff")]
 pub mod ark_ff_field;
 #[cfg(feature = "ark_ff")]
@@ -31,8 +68,10 @@ pub const WORD_FACTOR: usize = 2;
 // FixedField (static and const)
 //
 
-/// Element of a field (F) - a group where addition and multiplication are
+/// Element of a field (F) - a set where addition and multiplication are
 /// defined with their respective inverse operations.
+///
+/// This is a general trait for all fields, base and extension.
 pub trait FixedField:
     FixedRing
     + WithAssociatedInteger
@@ -55,9 +94,13 @@ pub trait FixedField:
 {
 }
 
+/// [`FixedField`] with a bunch of values known at compile time.
+pub trait ConstField: FixedField + ConstRing {}
+impl<F: FixedField + ConstRing> ConstField for F {}
+
 /// Base (non-extension) prime field with elements being self-sufficient, but
 /// whose metadata like modulus is not necessarily known at compile-time.
-pub trait FixedBaseField: FixedField + LiftToIntegerStatic {
+pub trait FixedBaseField: FixedField + LiftElementStatic<Self::Integer> {
     fn modulus() -> Self::Integer;
 
     /// (mod - 1) / 2
@@ -66,7 +109,7 @@ pub trait FixedBaseField: FixedField + LiftToIntegerStatic {
 
 /// Base (non-extension) prime field whose modulus and other metadata are
 /// constant values known at compile time.
-pub trait ConstBaseField: FixedField + LiftToIntegerStatic + ConstRing {
+pub trait ConstBaseField: ConstField + LiftElementStatic<Self::Integer> {
     const MODULUS: Self::Integer;
 
     /// (mod - 1) / 2
@@ -118,7 +161,7 @@ macro_rules! delegate_to_ref_binary {
 // FieldConfig (both static and dynamic)
 //
 
-pub trait FieldConfigOps: WithAssociatedInteger {
+pub trait FieldConfig: WithAssociatedInteger {
     type Element: Debug + Eq + Clone + Send + Sync + 'static;
 
     fn is_zero(&self, value: &Self::Element) -> bool;
@@ -151,9 +194,7 @@ pub trait FieldConfigOps: WithAssociatedInteger {
         self.checked_div(x, y).expect("Division by zero")
     }
 
-    /// x / y
-    ///
-    /// (Note: Field operations do not overflow)
+    /// x / y, [`None`] if `y == 0`
     #[inline(always)]
     fn checked_div(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
         Some(self.mul(x, &self.inv(y)?))
@@ -256,13 +297,13 @@ pub trait FieldConfigOps: WithAssociatedInteger {
 /// Fixed/constant prime fields are considered a special case of dynamic prime
 /// fields, and the bridge struct is [`FixedFieldConfig`].
 ///
-/// For base fields (and only for them), [`Self::Integer`] additionally serves
-/// as the modulus type and the target of `LiftToInteger*`.
+/// For base fields (and only for them), [`WithAssociatedInteger::Integer`]
+/// additionally serves as the modulus type and the target of `LiftElement*`.
 pub trait BaseFieldConfig:
     Sized
-    + FieldConfigOps
-    + LiftToIntegerDynamic
-    + ProjectElement<<Self as WithAssociatedInteger>::Integer>
+    + FieldConfig
+    + LiftElementDynamic<<Self as WithAssociatedInteger>::Integer>
+    + ProjectElementDynamic<<Self as WithAssociatedInteger>::Integer>
 {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError>;
 
@@ -280,7 +321,7 @@ pub trait BaseFieldConfig:
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub struct FixedFieldConfig<F: FixedField>(PhantomData<F>);
 
-impl<F: FixedField> FieldConfigOps for FixedFieldConfig<F> {
+impl<F: FixedField> FieldConfig for FixedFieldConfig<F> {
     type Element = F;
 
     #[inline(always)]
@@ -360,59 +401,52 @@ impl<F: FixedField> WithAssociatedInteger for FixedFieldConfig<F> {
     type Integer = F::Integer;
 }
 
-impl<F> LiftToIntegerDynamic for FixedFieldConfig<F>
-where
-    F: FixedBaseField + LiftToIntegerStatic,
-{
+impl<F: FixedBaseField> LiftElementDynamic<F::Integer> for FixedFieldConfig<F> {
     #[inline(always)]
-    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
-        LiftToIntegerStatic::lift_to_integer(value)
+    fn lift(&self, value: &F) -> F::Integer {
+        LiftElementStatic::lift(value)
     }
 }
 
-impl<F> ProjectElement<F::Integer> for FixedFieldConfig<F>
-where
-    F: FixedBaseField + LiftToIntegerStatic,
-{
-    fn project(&self, value: &F::Integer) -> Self::Element {
+impl<F: FixedBaseField> ProjectElementDynamic<F::Integer> for FixedFieldConfig<F> {
+    #[inline(always)]
+    fn project(&self, value: &F::Integer) -> F {
         F::from(value)
     }
 }
 
 //
-// WithAssociatedInteger/LiftToInteger
+// WithAssociatedInteger
 //
 
 pub trait WithAssociatedInteger {
     /// The exponent/order domain of this field: an integer semiring type wide
     /// enough to hold the exponents the field cares about (up to its order).
-    ///
-    ///
-    /// Note: this type is deliberately NOT the "modulus/lift" type in general
-    /// (an extension field would lift to a polynomial, not to an integer).
-    /// Only for base (prime) fields do the two coincide, as guaranteed by
-    /// [`BaseFieldConfig`] and the `LiftToInteger*` traits.
     type Integer: Semiring;
 }
 
-/// Lifts the structure element to an associated integer, applicable for fixed
-/// fields where this can be done on the element itself.
-pub trait LiftToIntegerStatic: WithAssociatedInteger {
-    /// Lift the field element to integer semiring using a natural approach.
+//
+// LiftElement
+//
+
+/// Lifts the field element to a specified type, applicable for fixed fields
+/// where this can be done on the element itself.
+pub trait LiftElementStatic<T> {
+    /// Lift the field element to a specified type using a natural approach.
     ///
-    /// Can be projected back to the field using
-    /// [`ProjectElement::project`] to get the same field element.
-    fn lift_to_integer(&self) -> Self::Integer;
+    /// Can be projected back to the field using [`From`] to get the same
+    /// field element.
+    fn lift(&self) -> T;
 }
 
-/// Lifts the structure element to an associated integer, applicable for
-/// general/dynamic fields where this requres [`BaseFieldConfig`] to work.
-pub trait LiftToIntegerDynamic: WithAssociatedInteger + FieldConfigOps {
-    /// Lift the field element to integer semiring using a natural approach.
+/// Lifts the field element to a specified type, applicable for
+/// general/dynamic fields where this requires a [`FieldConfig`] to work.
+pub trait LiftElementDynamic<T>: FieldConfig {
+    /// Lift the field element to a specified type using a natural approach.
     ///
     /// Can be projected back to the field using
-    /// [`ProjectElement::project`] to get the same field element.
-    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer;
+    /// [`ProjectElementDynamic::project`] to get the same field element.
+    fn lift(&self, value: &Self::Element) -> T;
 }
 
 //
@@ -420,14 +454,16 @@ pub trait LiftToIntegerDynamic: WithAssociatedInteger + FieldConfigOps {
 //
 
 /// Converts a given value to a field element of a current field.
-pub trait ProjectElement<T>: FieldConfigOps {
+///
+/// Static counterpart of this trait is just [`From`].
+pub trait ProjectElementDynamic<T>: FieldConfig {
     fn project(&self, value: &T) -> Self::Element;
 }
 
 /// Trivial implementation for fixed fields and types that implement `From<T>`.
-impl<F, T> ProjectElement<T> for F
+impl<F, T> ProjectElementDynamic<T> for F
 where
-    F: FieldConfigOps + FixedBaseField,
+    F: FieldConfig + FixedBaseField,
     F::Element: for<'a> From<&'a T>,
 {
     fn project(&self, value: &T) -> F::Element {
@@ -438,33 +474,33 @@ where
 /// The trait combines all `ProjectElement<u*>` and `ProjectElement<i*>` into
 /// one umbrella trait. Handy when one needs conversion functions for different
 /// primitive int types.
-pub trait ProjectPrimitiveIntegers:
-    ProjectElement<u8>
-    + ProjectElement<u16>
-    + ProjectElement<u32>
-    + ProjectElement<u64>
-    + ProjectElement<u128>
-    + ProjectElement<i8>
-    + ProjectElement<i16>
-    + ProjectElement<i32>
-    + ProjectElement<i64>
-    + ProjectElement<i128>
+pub trait ProjectPrimitiveIntegersDynamic:
+    ProjectElementDynamic<u8>
+    + ProjectElementDynamic<u16>
+    + ProjectElementDynamic<u32>
+    + ProjectElementDynamic<u64>
+    + ProjectElementDynamic<u128>
+    + ProjectElementDynamic<i8>
+    + ProjectElementDynamic<i16>
+    + ProjectElementDynamic<i32>
+    + ProjectElementDynamic<i64>
+    + ProjectElementDynamic<i128>
 {
 }
 
 /// Blanket implementation.
 impl<
-    T: ProjectElement<u8>
-        + ProjectElement<u16>
-        + ProjectElement<u32>
-        + ProjectElement<u64>
-        + ProjectElement<u128>
-        + ProjectElement<i8>
-        + ProjectElement<i16>
-        + ProjectElement<i32>
-        + ProjectElement<i64>
-        + ProjectElement<i128>,
-> ProjectPrimitiveIntegers for T
+    T: ProjectElementDynamic<u8>
+        + ProjectElementDynamic<u16>
+        + ProjectElementDynamic<u32>
+        + ProjectElementDynamic<u64>
+        + ProjectElementDynamic<u128>
+        + ProjectElementDynamic<i8>
+        + ProjectElementDynamic<i16>
+        + ProjectElementDynamic<i32>
+        + ProjectElementDynamic<i64>
+        + ProjectElementDynamic<i128>,
+> ProjectPrimitiveIntegersDynamic for T
 {
 }
 

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -1,7 +1,7 @@
 use super::*;
-use crate::{Semiring, Wrapper, boolean::Boolean, semiring::ark_ff_bigint::BigInt};
+use crate::{IntSemiring, LiftElement, Wrapper, boolean::Boolean, semiring::ark_ff_bigint::BigInt};
 use ark_ff::{
-    AdditiveGroup, FftField, LegendreSymbol, SqrtPrecomputation,
+    AdditiveGroup, BigInteger, FftField, LegendreSymbol, SqrtPrecomputation,
     fields::{Field as ArkWrappedField, PrimeField as ArkWrappedPrimeField},
 };
 use ark_serialize::{
@@ -17,7 +17,8 @@ use core::{
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
 use num_traits::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One,
+    Pow, Zero,
 };
 
 #[cfg(feature = "rand")]
@@ -462,17 +463,36 @@ impl<F: ArkWrappedPrimeField> Wrapper for ArkField<F> {
 // Semiring, Ring and Field
 //
 
-impl<F: ArkWrappedPrimeField> Semiring for ArkField<F> {}
+impl<F: ArkWrappedPrimeField> IntSemiring for ArkField<F> {
+    #[inline(always)]
+    fn is_odd(&self) -> bool {
+        // There's no way to check that efficiently
+        self.0.into_bigint().is_odd()
+    }
 
-impl<F: ArkWrappedPrimeField> Ring for ArkField<F> {}
-
-impl<F, const N: usize> FixedField for ArkField<F> where
-    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>
-{
+    #[inline(always)]
+    fn is_even(&self) -> bool {
+        // There's no way to check that efficiently
+        self.0.into_bigint().is_even()
+    }
 }
 
-// TODO: Can be made into ConstField, but it's hard to compute MODULUS - 1
-impl<F, const N: usize> FixedBaseField for ArkField<F>
+impl<F: ArkWrappedPrimeField> Bounded for ArkField<F> {
+    #[inline(always)]
+    fn min_value() -> Self {
+        <Self as ConstZero>::ZERO
+    }
+
+    /// The largest residue, `modulus - 1`.
+    #[allow(clippy::arithmetic_side_effects)] // Negation in a field cannot fail
+    #[inline(always)]
+    fn max_value() -> Self {
+        -<Self as ConstOne>::ONE
+    }
+}
+
+// TODO: Can be made into ConstBaseField, but it's hard to compute MODULUS - 1
+impl<F, const N: usize> BaseField for ArkField<F>
 where
     F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
 {
@@ -492,7 +512,7 @@ where
     type Integer = BigInt<N>;
 }
 
-impl<F, const N: usize> LiftElementStatic<<Self as WithAssociatedInteger>::Integer> for ArkField<F>
+impl<F, const N: usize> LiftElement<<Self as WithAssociatedInteger>::Integer> for ArkField<F>
 where
     F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
 {
@@ -741,7 +761,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FixedBaseField, FixedRing, ensure_type_implements_trait};
+    use crate::{BaseField, Ring, ensure_type_implements_trait};
     use alloc::vec::Vec;
     use ark_ff::{Fp64, Fp256, MontBackend, MontConfig};
     use core::str::FromStr;
@@ -758,10 +778,10 @@ mod tests {
     #[test]
     fn ensure_traits() {
         ensure_type_implements_trait!(F, Wrapper);
-        // Should be ConstRing, but it's hard to compute MODULUS - 1 for
+        // Should be ConstBaseField, but it's hard to compute MODULUS - 1 for
         // Self::BigInt
-        ensure_type_implements_trait!(F, FixedRing);
-        ensure_type_implements_trait!(F, FixedBaseField);
+        ensure_type_implements_trait!(F, Ring);
+        ensure_type_implements_trait!(F, BaseField);
     }
 
     #[test]

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Semiring, boolean::Boolean, semiring::ark_ff_bigint::BigInt};
+use crate::{Semiring, Wrapper, boolean::Boolean, semiring::ark_ff_bigint::BigInt};
 use ark_ff::{
     AdditiveGroup, FftField, LegendreSymbol, SqrtPrecomputation,
     fields::{Field as ArkWrappedField, PrimeField as ArkWrappedPrimeField},
@@ -29,26 +29,13 @@ use rand::distr::StandardUniform;
 #[infallible_checked_unary_op((CheckedNeg, neg))]
 #[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
 #[repr(transparent)]
-pub struct ArkField<F: ArkWrappedPrimeField>(F);
+pub struct ArkField<F: ArkWrappedPrimeField>(pub F);
 
 impl<F: ArkWrappedPrimeField> ArkField<F> {
     /// Wraps a given value into this wrapper type
     #[inline(always)]
     pub const fn new(value: F) -> Self {
         Self(value)
-    }
-
-    /// Get the reference to the wrapped value
-    #[inline(always)]
-    #[must_use]
-    pub const fn inner(&self) -> &F {
-        &self.0
-    }
-
-    /// Get the wrapped value, consuming self
-    #[inline(always)]
-    pub const fn into_inner(self) -> F {
-        self.0
     }
 }
 
@@ -444,17 +431,10 @@ impl<F: ArkWrappedPrimeField + Into<num_bigint::BigUint>> From<ArkField<F>>
 }
 
 //
-// Semiring, Ring and Field
+// Wrapper
 //
 
-impl<F: ArkWrappedPrimeField> Semiring for ArkField<F> {}
-
-impl<F: ArkWrappedPrimeField> Ring for ArkField<F> {}
-
-impl<F, const N: usize> FixedField for ArkField<F>
-where
-    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
-{
+impl<F: ArkWrappedPrimeField> Wrapper for ArkField<F> {
     type Inner = F;
 
     #[inline(always)]
@@ -472,9 +452,23 @@ where
         self.0
     }
 
+    #[inline(always)]
     fn new_unchecked(inner: Self::Inner) -> Self {
         Self(inner)
     }
+}
+
+//
+// Semiring, Ring and Field
+//
+
+impl<F: ArkWrappedPrimeField> Semiring for ArkField<F> {}
+
+impl<F: ArkWrappedPrimeField> Ring for ArkField<F> {}
+
+impl<F, const N: usize> FixedField for ArkField<F> where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>
+{
 }
 
 // TODO: Can be made into ConstField, but it's hard to compute MODULUS - 1
@@ -763,6 +757,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(F, Wrapper);
         // Should be ConstRing, but it's hard to compute MODULUS - 1 for
         // Self::BigInt
         ensure_type_implements_trait!(F, FixedRing);

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -492,12 +492,12 @@ where
     type Integer = BigInt<N>;
 }
 
-impl<F, const N: usize> LiftToIntegerStatic for ArkField<F>
+impl<F, const N: usize> LiftElementStatic<<Self as WithAssociatedInteger>::Integer> for ArkField<F>
 where
     F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
 {
     #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
+    fn lift(&self) -> <Self as WithAssociatedInteger>::Integer {
         BigInt::new(self.0.into_bigint())
     }
 }
@@ -776,7 +776,7 @@ mod tests {
 
         // Lifting to integer and projecting back yields the original element.
         for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {
-            assert_eq!(F::from(x.lift_to_integer()), x);
+            assert_eq!(F::from(x.lift()), x);
         }
     }
 

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -428,12 +428,11 @@ impl<F: ArkWrappedPrimeField> Semiring for ArkField<F> {}
 
 impl<F: ArkWrappedPrimeField> Ring for ArkField<F> {}
 
-impl<F, const N: usize> Field for ArkField<F>
+impl<F, const N: usize> FixedField for ArkField<F>
 where
     F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
 {
     type Inner = F;
-    type Integer = BigInt<N>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -450,52 +449,39 @@ where
         self.0
     }
 
-    #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
-        BigInt::new(self.0.into_bigint())
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
     }
 }
 
-impl<F: ArkWrappedPrimeField> HasPrimeFieldConfig for ArkField<F> {
-    type Config = ();
-
-    fn cfg(&self) -> &Self::Config {
-        &()
-    }
-}
-
-// TODO: Can be made into ConstPrimeField, but it's hard to compute MODULUS - 1
-impl<F, const N: usize> PrimeField for ArkField<F>
+// TODO: Can be made into ConstField, but it's hard to compute MODULUS - 1
+impl<F, const N: usize> FixedBaseField for ArkField<F>
 where
     F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
 {
-    fn modulus(_cfg: &Self::Config) -> Self::Integer {
+    fn modulus() -> Self::Integer {
         BigInt::new(Self::MODULUS)
     }
 
-    fn modulus_minus_one_div_two(_cfg: &Self::Config) -> Self::Integer {
+    fn modulus_minus_one_div_two() -> Self::Integer {
         BigInt::new(Self::MODULUS_MINUS_ONE_DIV_TWO)
     }
+}
 
-    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
-        debug_assert_eq!(*modulus.inner(), Self::MODULUS);
-        Ok(())
-    }
+impl<F, const N: usize> WithAssociatedInteger for ArkField<F>
+where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
+{
+    type Integer = BigInt<N>;
+}
 
-    fn new_unchecked_with_cfg(inner: Self::Inner, _cfg: &Self::Config) -> Self {
-        Self(inner)
-    }
-
-    fn is_zero(value: &Self) -> bool {
-        Zero::is_zero(value)
-    }
-
-    fn zero_with_cfg(_cfg: &Self::Config) -> Self {
-        Zero::zero()
-    }
-
-    fn one_with_cfg(_cfg: &Self::Config) -> Self {
-        todo!()
+impl<F, const N: usize> LiftToIntegerStatic for ArkField<F>
+where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
+{
+    #[inline(always)]
+    fn lift_to_integer(&self) -> Self::Integer {
+        BigInt::new(self.0.into_bigint())
     }
 }
 
@@ -738,7 +724,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FixedRing, ensure_type_implements_trait};
+    use crate::{FixedBaseField, FixedRing, ensure_type_implements_trait};
     use alloc::vec::Vec;
     use ark_ff::{Fp64, Fp256, MontBackend, MontConfig};
     use core::str::FromStr;
@@ -753,11 +739,11 @@ mod tests {
     type F = ArkField<ArkFp>;
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         // Should be ConstRing, but it's hard to compute MODULUS - 1 for
         // Self::BigInt
         ensure_type_implements_trait!(F, FixedRing);
-        ensure_type_implements_trait!(F, PrimeField);
+        ensure_type_implements_trait!(F, FixedBaseField);
     }
 
     #[test]
@@ -768,7 +754,7 @@ mod tests {
         assert!(!o.is_zero());
         assert_ne!(z, o);
 
-        assert_eq!(F::from(<F as PrimeField>::modulus(&())), z);
+        assert_eq!(F::from(F::modulus()), z);
 
         // Lifting to integer and projecting back yields the original element.
         for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -220,6 +220,29 @@ impl<F: ArkWrappedPrimeField> Pow<u32> for ArkField<F> {
     }
 }
 
+impl<F, const N: usize> Pow<BigInt<N>> for ArkField<F>
+where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
+{
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, rhs: BigInt<N>) -> Self::Output {
+        self.pow(&rhs)
+    }
+}
+
+impl<F, const N: usize> Pow<&BigInt<N>> for ArkField<F>
+where
+    F: ArkWrappedPrimeField<BigInt = ark_ff::BigInt<N>>,
+{
+    type Output = Self;
+
+    fn pow(self, rhs: &BigInt<N>) -> Self::Output {
+        Self(self.0.pow(rhs.inner()))
+    }
+}
+
 impl<F: ArkWrappedPrimeField> Inv for ArkField<F> {
     type Output = Option<Self>;
 
@@ -912,31 +935,37 @@ mod tests {
         let base = F::from(2_u64);
 
         // 2^0 = 1
-        assert_eq!(base.pow(0), F::one());
+        assert_eq!(base.pow(0_u32), F::one());
 
         // 2^1 = 2
-        assert_eq!(base.pow(1), base);
+        assert_eq!(base.pow(1_u32), base);
 
         // 2^3 = 8
-        assert_eq!(base.pow(3), F::from(8_u64));
+        assert_eq!(base.pow(3_u32), F::from(8_u64));
 
         // 2^10 = 1024
-        assert_eq!(base.pow(10), F::from(1024_u64));
+        assert_eq!(base.pow(10_u32), F::from(1024_u64));
 
         // Test with different base
         let base = F::from(3_u64);
 
         // 3^4 = 81
-        assert_eq!(base.pow(4), F::from(81_u64));
+        assert_eq!(base.pow(4_u32), F::from(81_u64));
 
         // Test with base 1
         let base = F::from(1_u64);
-        assert_eq!(base.pow(1000), F::from(1_u64));
+        assert_eq!(base.pow(1000_u32), F::from(1_u64));
 
         // Test with base 0
         let base = F::from(0_u64);
-        assert_eq!(base.pow(0), F::one()); // 0^0 = 1 by convention
-        assert_eq!(base.pow(10), F::zero()); // 0^n = 0 for n > 0
+        assert_eq!(base.pow(0_u32), F::one()); // 0^0 = 1 by convention
+        assert_eq!(base.pow(10_u32), F::zero()); // 0^n = 0 for n > 0
+
+        // Same checks via `BigInt` (`Self::Integer`) exponents
+        let base = F::from(2_u64);
+        assert_eq!(base.pow(BigInt::from(0_u64)), F::one());
+        assert_eq!(base.pow(&BigInt::from(3_u64)), F::from(8_u64));
+        assert_eq!(base.pow(BigInt::from(10_u64)), F::from(1024_u64));
     }
 
     #[test]

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntRing, IntSemiring, Semiring, boolean::Boolean};
+use crate::{IntRing, IntSemiring, Semiring, Wrapper, boolean::Boolean};
 use ark_ff::{
     AdditiveGroup, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
     SqrtPrecomputation,
@@ -33,25 +33,13 @@ use rand::distr::StandardUniform;
 #[infallible_checked_unary_op((CheckedNeg, neg))]
 #[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
 #[repr(transparent)]
-pub struct Fp<P: FpConfig<N>, const N: usize>(ArkWrappedFp<P, N>);
+pub struct Fp<P: FpConfig<N>, const N: usize>(pub ArkWrappedFp<P, N>);
 
 impl<P: FpConfig<N>, const N: usize> Fp<P, N> {
     /// Wraps a given value into this wrapper type
     #[inline(always)]
     pub const fn new(value: ArkWrappedFp<P, N>) -> Self {
         Self(value)
-    }
-
-    /// Get the reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner(&self) -> &ArkWrappedFp<P, N> {
-        &self.0
-    }
-
-    /// Get the wrapped value, consuming self
-    #[inline(always)]
-    pub const fn into_inner(self) -> ArkWrappedFp<P, N> {
-        self.0
     }
 }
 
@@ -65,9 +53,7 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
 
     #[inline(always)]
     pub const fn new_from_bigint(element: BigInt<N>) -> Self {
-        Self(ArkWrappedFp::<MontBackend<T, N>, N>::new(
-            element.into_inner(),
-        ))
+        Self(ArkWrappedFp::<MontBackend<T, N>, N>::new(element.0))
     }
 }
 
@@ -99,7 +85,7 @@ impl<P: FpConfig<N>, const N: usize> Deref for Fp<P, N> {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.inner()
+        &self.0
     }
 }
 
@@ -477,6 +463,34 @@ impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for num_bigint::BigUint {
 }
 
 //
+// Wrapper
+//
+
+impl<M: MontConfig<N>, const N: usize> Wrapper for Fp<MontBackend<M, N>, N> {
+    type Inner = BigInt<N>;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        BigInt::new_ref(&self.0.0)
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        BigInt::new_ref_mut(&mut self.0.0)
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        BigInt::new(self.0.0)
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(ArkWrappedFp::new_unchecked(inner.into_inner()))
+    }
+}
+
+//
 // Semiring, Ring and Field
 //
 
@@ -517,28 +531,7 @@ impl<P: FpConfig<N>, const N: usize> IntSemiring for Fp<P, N> {
     }
 }
 
-impl<M: MontConfig<N>, const N: usize> FixedField for Fp<MontBackend<M, N>, N> {
-    type Inner = BigInt<N>;
-
-    #[inline(always)]
-    fn inner(&self) -> &Self::Inner {
-        BigInt::new_ref(&self.0.0)
-    }
-
-    #[inline(always)]
-    fn inner_mut(&mut self) -> &mut Self::Inner {
-        BigInt::new_ref_mut(&mut self.0.0)
-    }
-
-    #[inline(always)]
-    fn into_inner(self) -> Self::Inner {
-        BigInt::new(self.0.0)
-    }
-
-    fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(ArkWrappedFp::new_unchecked(inner.into_inner()))
-    }
-}
+impl<M: MontConfig<N>, const N: usize> FixedField for Fp<MontBackend<M, N>, N> {}
 
 /// ConstPrimeField is only implemented for MontConfig and MontBackend
 impl<M: MontConfig<N>, const N: usize> ConstBaseField for Fp<MontBackend<M, N>, N> {
@@ -799,6 +792,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(F, Wrapper);
         ensure_type_implements_trait!(F, ConstIntRing);
         ensure_type_implements_trait!(F, ConstBaseField);
         ensure_type_implements_trait!(F, From<BigInt<4>>);
@@ -1202,11 +1196,13 @@ mod tests {
         let wrapped = F::new(inner);
         assert_eq!(wrapped, F::from(123_u64));
 
-        // Test inner() and into_inner()
+        // Test Wrapper::inner()/into_inner()/new_unchecked: the inner
+        // representation is the Montgomery-form BigInt
         let value = F::from(456_u64);
-        let inner_ref = value.inner();
-        assert_eq!(*inner_ref, ark_ff::MontFp!("456"));
-        assert_eq!(value.into_inner(), ark_ff::MontFp!("456"));
+        let expected: F = F::new(ark_ff::MontFp!("456"));
+        assert_eq!(*value.inner(), BigInt::new(expected.0.0));
+        assert_eq!(value.into_inner(), BigInt::new(expected.0.0));
+        assert_eq!(F::new_unchecked(value.into_inner()), value);
     }
 
     #[test]

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -487,32 +487,21 @@ impl<T: MontConfig<N>, const N: usize> ConstSemiring for Fp<MontBackend<T, N>, N
 impl<P: FpConfig<N>, const N: usize> Ring for Fp<P, N> {}
 
 impl<P: FpConfig<N>, const N: usize> IntSemiring for Fp<P, N> {
+    #[inline(always)]
     fn is_odd(&self) -> bool {
+        // There's no way to check that efficiently
         self.0.into_bigint().is_odd()
     }
 
+    #[inline(always)]
     fn is_even(&self) -> bool {
+        // There's no way to check that efficiently
         self.0.into_bigint().is_even()
     }
 }
 
-impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
-    fn checked_abs(&self) -> Option<Self> {
-        Some(*self)
-    }
-
-    fn is_positive(&self) -> bool {
-        !self.is_zero()
-    }
-
-    fn is_negative(&self) -> bool {
-        false
-    }
-}
-
-impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
+impl<M: MontConfig<N>, const N: usize> FixedField for Fp<MontBackend<M, N>, N> {
     type Inner = BigInt<N>;
-    type Integer = BigInt<N>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -529,21 +518,27 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
         BigInt::new(self.0.0)
     }
 
-    #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
-        BigInt::new(self.0.into_bigint())
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(ArkWrappedFp::new_unchecked(inner.into_inner()))
     }
 }
 
 /// ConstPrimeField is only implemented for MontConfig and MontBackend
-impl<M: MontConfig<N>, const N: usize> ConstPrimeField for Fp<MontBackend<M, N>, N> {
+impl<M: MontConfig<N>, const N: usize> ConstBaseField for Fp<MontBackend<M, N>, N> {
     const MODULUS: Self::Integer = BigInt::new(M::MODULUS);
-    const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = BigInt::new(
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = BigInt::new(
         <ArkWrappedFp<MontBackend<M, N>, N> as ArkPrimeField>::MODULUS_MINUS_ONE_DIV_TWO,
     );
+}
 
-    fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(ArkWrappedFp::new_unchecked(inner.into_inner()))
+impl<P: FpConfig<N>, const N: usize> WithAssociatedInteger for Fp<P, N> {
+    type Integer = BigInt<N>;
+}
+
+impl<P: FpConfig<N>, const N: usize> LiftToIntegerStatic for Fp<P, N> {
+    #[inline(always)]
+    fn lift_to_integer(&self) -> Self::Integer {
+        BigInt::new(self.0.into_bigint())
     }
 }
 
@@ -786,9 +781,10 @@ mod tests {
     type F = Fp<MontBackend<TestFpConfig, 4>, 4>;
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         ensure_type_implements_trait!(F, ConstIntRing);
-        ensure_type_implements_trait!(F, FromPrimitiveWithConfig);
+        ensure_type_implements_trait!(F, ConstBaseField);
+        ensure_type_implements_trait!(F, From<BigInt<4>>);
     }
 
     #[test]
@@ -799,7 +795,7 @@ mod tests {
         assert!(!o.is_zero());
         assert_ne!(z, o);
 
-        assert_eq!(F::from(<F as PrimeField>::modulus(&())), z);
+        assert_eq!(F::from(<F as FixedBaseField>::modulus()), z);
 
         // Lifting to integer and projecting back yields the original element.
         for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntSemiring, Semiring, Wrapper, boolean::Boolean};
+use crate::{IntSemiring, LiftElement, Wrapper, boolean::Boolean};
 use ark_ff::{
     AdditiveGroup, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
     SqrtPrecomputation,
@@ -19,7 +19,8 @@ use core::{
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
 use num_traits::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One,
+    Pow, Zero,
 };
 
 use crate::ark_ff_bigint::BigInt;
@@ -46,6 +47,22 @@ impl<P: FpConfig<N>, const N: usize> Fp<P, N> {
 impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
     #[doc(hidden)]
     pub const INV: u64 = T::INV;
+    /// The largest residue, `modulus - 1`.
+    pub const MAX: Self = {
+        let mut value = T::MODULUS;
+        // Subtract one in const context (can't use checked_sub)
+        let mut i = 0;
+        while i < N {
+            if value.0[i] > 0 {
+                value.0[i] -= 1;
+                break;
+            } else {
+                value.0[i] = u64::MAX;
+                i += 1;
+            }
+        }
+        Self(ArkWrappedFp::new(value))
+    };
     #[doc(hidden)]
     pub const R: BigInt<N> = BigInt::new(T::R);
     #[doc(hidden)]
@@ -498,28 +515,18 @@ impl<M: MontConfig<N>, const N: usize> Wrapper for Fp<MontBackend<M, N>, N> {
 // Semiring, Ring and Field
 //
 
-impl<P: FpConfig<N>, const N: usize> Semiring for Fp<P, N> {}
+impl<M: MontConfig<N>, const N: usize> Bounded for Fp<MontBackend<M, N>, N> {
+    #[inline(always)]
+    fn min_value() -> Self {
+        <Self as ConstZero>::ZERO
+    }
 
-impl<T: MontConfig<N>, const N: usize> ConstSemiring for Fp<MontBackend<T, N>, N> {
-    const MAX: Self = {
-        let mut value = T::MODULUS;
-        // Subtract one in const context (can't use checked_sub)
-        let mut i = 0;
-        while i < N {
-            if value.0[i] > 0 {
-                value.0[i] -= 1;
-                break;
-            } else {
-                value.0[i] = u64::MAX;
-                i += 1;
-            }
-        }
-        Self(ArkWrappedFp::new(value))
-    };
-    const MIN: Self = <Self as ConstZero>::ZERO;
+    /// The largest residue, `modulus - 1`.
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::MAX
+    }
 }
-
-impl<P: FpConfig<N>, const N: usize> Ring for Fp<P, N> {}
 
 impl<P: FpConfig<N>, const N: usize> IntSemiring for Fp<P, N> {
     #[inline(always)]
@@ -535,9 +542,7 @@ impl<P: FpConfig<N>, const N: usize> IntSemiring for Fp<P, N> {
     }
 }
 
-impl<M: MontConfig<N>, const N: usize> FixedField for Fp<MontBackend<M, N>, N> {}
-
-/// ConstPrimeField is only implemented for MontConfig and MontBackend
+/// ConstBaseField is only implemented for MontConfig and MontBackend
 impl<M: MontConfig<N>, const N: usize> ConstBaseField for Fp<MontBackend<M, N>, N> {
     const MODULUS: Self::Integer = BigInt::new(M::MODULUS);
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = BigInt::new(
@@ -549,7 +554,7 @@ impl<P: FpConfig<N>, const N: usize> WithAssociatedInteger for Fp<P, N> {
     type Integer = BigInt<N>;
 }
 
-impl<P: FpConfig<N>, const N: usize> LiftElementStatic<<Self as WithAssociatedInteger>::Integer>
+impl<P: FpConfig<N>, const N: usize> LiftElement<<Self as WithAssociatedInteger>::Integer>
     for Fp<P, N>
 {
     #[inline(always)]
@@ -783,7 +788,7 @@ macro_rules! mont_fp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ConstIntRing, ensure_type_implements_trait};
+    use crate::{ConstField, ensure_type_implements_trait};
     use alloc::{format, vec::Vec};
     use ark_ff::{MontBackend, MontConfig};
     use core::str::FromStr;
@@ -799,7 +804,7 @@ mod tests {
     #[test]
     fn ensure_traits() {
         ensure_type_implements_trait!(F, Wrapper);
-        ensure_type_implements_trait!(F, ConstIntRing);
+        ensure_type_implements_trait!(F, ConstField);
         ensure_type_implements_trait!(F, ConstBaseField);
         ensure_type_implements_trait!(F, From<BigInt<4>>);
     }
@@ -812,7 +817,7 @@ mod tests {
         assert!(!o.is_zero());
         assert_ne!(z, o);
 
-        assert_eq!(F::from(<F as FixedBaseField>::modulus()), z);
+        assert_eq!(F::from(<F as BaseField>::modulus()), z);
 
         // Lifting to integer and projecting back yields the original element.
         for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {
@@ -822,18 +827,18 @@ mod tests {
 
     #[test]
     fn min_max() {
-        assert_eq!(F::MIN, F::zero());
+        assert_eq!(F::min_value(), F::zero());
         assert_eq!(
-            F::MAX,
+            F::max_value(),
             F::from_str(
                 "115792089237316195423570985008687907853269984665640564039457584007908834671662"
             )
             .unwrap()
         );
 
-        assert_eq!(F::MAX + F::one(), F::zero());
-        assert_eq!(F::MIN - F::one(), F::MAX);
-        assert_eq!(F::MAX * F::MAX, F::one());
+        assert_eq!(F::max_value() + F::one(), F::zero());
+        assert_eq!(F::min_value() - F::one(), F::max_value());
+        assert_eq!(F::max_value() * F::max_value(), F::one());
     }
 
     #[test]

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -545,9 +545,11 @@ impl<P: FpConfig<N>, const N: usize> WithAssociatedInteger for Fp<P, N> {
     type Integer = BigInt<N>;
 }
 
-impl<P: FpConfig<N>, const N: usize> LiftToIntegerStatic for Fp<P, N> {
+impl<P: FpConfig<N>, const N: usize> LiftElementStatic<<Self as WithAssociatedInteger>::Integer>
+    for Fp<P, N>
+{
     #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
+    fn lift(&self) -> <Self as WithAssociatedInteger>::Integer {
         BigInt::new(self.0.into_bigint())
     }
 }
@@ -747,7 +749,7 @@ impl<P: FpConfig<N>, const N: usize> ArkPrimeField for Fp<P, N> {
     }
 
     fn into_bigint(self) -> Self::BigInt {
-        self.lift_to_integer()
+        self.lift()
     }
 }
 
@@ -810,7 +812,7 @@ mod tests {
 
         // Lifting to integer and projecting back yields the original element.
         for x in [z, o, F::from(2_u64), F::from(123456789_u64)] {
-            assert_eq!(F::from(x.lift_to_integer()), x);
+            assert_eq!(F::from(x.lift()), x);
         }
     }
 

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntRing, IntSemiring, Semiring, Wrapper, boolean::Boolean};
+use crate::{IntSemiring, Semiring, Wrapper, boolean::Boolean};
 use ark_ff::{
     AdditiveGroup, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
     SqrtPrecomputation,

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -99,6 +99,7 @@ impl<P: FpConfig<N>, const N: usize> Clone for Fp<P, N> {
 impl<P: FpConfig<N>, const N: usize> Copy for Fp<P, N> {}
 
 impl<P: FpConfig<N>, const N: usize> PartialEq for Fp<P, N> {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
     }
@@ -107,18 +108,21 @@ impl<P: FpConfig<N>, const N: usize> PartialEq for Fp<P, N> {
 impl<P: FpConfig<N>, const N: usize> Eq for Fp<P, N> {}
 
 impl<P: FpConfig<N>, const N: usize> PartialOrd for Fp<P, N> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl<P: FpConfig<N>, const N: usize> Ord for Fp<P, N> {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         Ord::cmp(&self.0, &other.0)
     }
 }
 
 impl<P: FpConfig<N>, const N: usize> Hash for Fp<P, N> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state)
     }

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -278,6 +278,23 @@ impl<P: FpConfig<N>, const N: usize> Pow<u32> for Fp<P, N> {
     }
 }
 
+impl<P: FpConfig<N>, const N: usize> Pow<BigInt<N>> for Fp<P, N> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, rhs: BigInt<N>) -> Self::Output {
+        self.pow(&rhs)
+    }
+}
+
+impl<P: FpConfig<N>, const N: usize> Pow<&BigInt<N>> for Fp<P, N> {
+    type Output = Self;
+
+    fn pow(self, rhs: &BigInt<N>) -> Self::Output {
+        Self(self.0.pow(rhs.inner()))
+    }
+}
+
 impl<P: FpConfig<N>, const N: usize> Inv for Fp<P, N> {
     type Output = Option<Self>;
 
@@ -968,31 +985,37 @@ mod tests {
         let base = F::from(2_u64);
 
         // 2^0 = 1
-        assert_eq!(base.pow(0), F::one());
+        assert_eq!(base.pow(0_u32), F::one());
 
         // 2^1 = 2
-        assert_eq!(base.pow(1), base);
+        assert_eq!(base.pow(1_u32), base);
 
         // 2^3 = 8
-        assert_eq!(base.pow(3), F::from(8_u64));
+        assert_eq!(base.pow(3_u32), F::from(8_u64));
 
         // 2^10 = 1024
-        assert_eq!(base.pow(10), F::from(1024_u64));
+        assert_eq!(base.pow(10_u32), F::from(1024_u64));
 
         // Test with different base
         let base = F::from(3_u64);
 
         // 3^4 = 81
-        assert_eq!(base.pow(4), F::from(81_u64));
+        assert_eq!(base.pow(4_u32), F::from(81_u64));
 
         // Test with base 1
         let base = F::from(1_u64);
-        assert_eq!(base.pow(1000), F::from(1_u64));
+        assert_eq!(base.pow(1000_u32), F::from(1_u64));
 
         // Test with base 0
         let base = F::from(0_u64);
-        assert_eq!(base.pow(0), F::one()); // 0^0 = 1 by convention
-        assert_eq!(base.pow(10), F::zero()); // 0^n = 0 for n > 0
+        assert_eq!(base.pow(0_u32), F::one()); // 0^0 = 1 by convention
+        assert_eq!(base.pow(10_u32), F::zero()); // 0^n = 0 for n > 0
+
+        // Same checks via `BigInt` (`Self::Integer`) exponents
+        let base = F::from(2_u64);
+        assert_eq!(base.pow(BigInt::from(0_u64)), F::one());
+        assert_eq!(base.pow(&BigInt::from(3_u64)), F::from(8_u64));
+        assert_eq!(base.pow(BigInt::from(10_u64)), F::from(1024_u64));
     }
 
     #[test]

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -154,6 +154,17 @@ impl FieldConfigOps for BoxedMontyField {
         out.into()
     }
 
+    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
+        crypto_bigint_helpers::pow::pow(
+            &x.0,
+            y.as_limbs(),
+            BoxedUint::new(self.params.as_ref().one().clone()),
+            BoxedUint::new_ref(self.params.modulus().as_ref()),
+            self.params.as_ref().mod_neg_inv(),
+        )
+        .into()
+    }
+
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
         crypto_bigint_helpers::pow::pow_u32(
             &x.0,
@@ -536,35 +547,45 @@ mod tests {
     fn pow_operation() {
         let f = make_f();
 
+        // Check both `pow` flavors: a `u32` exponent and the same exponent
+        // as a `Self::Integer`.
+        macro_rules! assert_pow {
+            ($base:expr, $exp:expr, $expected:expr) => {{
+                let exp: u32 = $exp;
+                assert_eq!(f.pow_u32(&$base, exp), $expected);
+                assert_eq!(f.pow(&$base, &BoxedUint::from(exp)), $expected);
+            }};
+        }
+
         // Test basic exponentiation
         let base = f.project(&2);
 
         // 2^0 = 1
-        assert_eq!(f.pow_u32(&base, 0), f.one());
+        assert_pow!(base, 0, f.one());
 
         // 2^1 = 2
-        assert_eq!(f.pow_u32(&base, 1), base);
+        assert_pow!(base, 1, base.clone());
 
         // 2^3 = 8
-        assert_eq!(f.pow_u32(&base, 3), f.project(&8));
+        assert_pow!(base, 3, f.project(&8));
 
         // 2^10 = 1024
-        assert_eq!(f.pow_u32(&base, 10), f.project(&1024));
+        assert_pow!(base, 10, f.project(&1024));
 
         // Test with different base
         let base = f.project(&3);
 
         // 3^4 = 81
-        assert_eq!(f.pow_u32(&base, 4), f.project(&81));
+        assert_pow!(base, 4, f.project(&81));
 
         // Test with base 1
         let base = f.one();
-        assert_eq!(f.pow_u32(&base, 1000), f.one());
+        assert_pow!(base, 1000, f.one());
 
         // Test with base 0
         let base = f.zero();
-        assert_eq!(f.pow_u32(&base, 0), f.one()); // 0^0 = 1 by convention
-        assert_eq!(f.pow_u32(&base, 10), f.zero()); // 0^n = 0 for n > 0
+        assert_pow!(base, 0, f.one()); // 0^0 = 1 by convention
+        assert_pow!(base, 10, f.zero()); // 0^n = 0 for n > 0
     }
 
     #[test]
@@ -588,7 +609,23 @@ mod tests {
                 expected.as_montgomery(),
                 "{base}^{exp} diverges from BoxedMontyForm::pow"
             );
+            assert_eq!(
+                f.pow(&x, &BoxedUint::from(exp)).0.inner(),
+                expected.as_montgomery(),
+                "{base}^{exp} (integer exponent) diverges from BoxedMontyForm::pow"
+            );
         }
+
+        // An exponent wider than u32 (integer-exponent `pow` only)
+        let x = f.project(&123456789_u64);
+        let exp = u128::MAX;
+        let expected = BoxedMontyForm::from_montgomery(x.0.inner().clone(), &f.params)
+            .pow(&crypto_bigint::BoxedUint::from(exp));
+        assert_eq!(
+            f.pow(&x, &BoxedUint::from(exp)).0.inner(),
+            expected.as_montgomery(),
+            "u128::MAX exponent diverges from BoxedMontyForm::pow"
+        );
     }
 
     #[test]

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     IntRing, Wrapper, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
-    crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    crypto_bigint_int::Int, crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
@@ -181,7 +181,7 @@ impl FieldConfig for BoxedMontyField {
         // Note: CIOS multiplication is worse for this
         let modulus = BoxedUint::new_ref(self.params.modulus().as_ref());
         let mut out = BoxedUint::zero_with_precision(self.bits_precision());
-        let carry = crypto_bigint_helpers::mul::monty_mul_limbs(
+        let carry = helpers::mul::monty_mul_limbs(
             x.0.as_limbs(),
             y.0.as_limbs(),
             out.as_mut_limbs(),
@@ -194,7 +194,7 @@ impl FieldConfig for BoxedMontyField {
     }
 
     fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
-        crypto_bigint_helpers::pow::pow_bounded_exp(
+        helpers::pow::pow_bounded_exp(
             &x.0,
             y.as_limbs(),
             y.bits_precision(),
@@ -206,7 +206,7 @@ impl FieldConfig for BoxedMontyField {
     }
 
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
-        crypto_bigint_helpers::pow::pow_u32(
+        helpers::pow::pow_u32(
             &x.0,
             y,
             BoxedUint::new(self.params.as_ref().one().clone()),
@@ -346,7 +346,7 @@ impl LiftElementDynamic<<Self as WithAssociatedInteger>::Integer> for BoxedMonty
     #[inline(always)]
     fn lift(&self, value: &Self::Element) -> Self::Integer {
         let mut out = BoxedUint::zero_with_precision(value.bits_precision());
-        crypto_bigint_helpers::monty_retrieve_inner(
+        helpers::monty_retrieve_inner(
             value.0.as_limbs(),
             out.as_mut_limbs(),
             self.modulus().as_limbs(),

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -130,7 +130,7 @@ impl Display for BoxedMontyField {
 // Field operations
 //
 
-impl FieldConfigOps for BoxedMontyField {
+impl FieldConfig for BoxedMontyField {
     type Element = BoxedMontyFieldElement;
 
     fn is_zero(&self, value: &Self::Element) -> bool {
@@ -236,7 +236,7 @@ impl FieldConfigOps for BoxedMontyField {
 macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
-            impl ProjectElement<$t> for BoxedMontyField {
+            impl ProjectElementDynamic<$t> for BoxedMontyField {
                 fn project(&self, value: &$t) -> Self::Element {
                     let abs: BoxedUint = value.into();
                     self.project(&abs.resize(self.modulus().bits_precision()))
@@ -249,7 +249,7 @@ macro_rules! impl_from_unsigned {
 macro_rules! impl_from_signed {
     ($($t:ty),* $(,)?) => {
         $(
-            impl ProjectElement<$t> for BoxedMontyField {
+            impl ProjectElementDynamic<$t> for BoxedMontyField {
                 fn project(&self, value: &$t) -> Self::Element {
                     let magnitude = BoxedUint::from(value.abs_diff(0)).resize(self.modulus().bits_precision());
                     let magnitude = self.project(&magnitude);
@@ -263,20 +263,20 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
-impl ProjectElement<bool> for BoxedMontyField {
+impl ProjectElementDynamic<bool> for BoxedMontyField {
     fn project(&self, value: &bool) -> Self::Element {
         if *value { self.one() } else { self.zero() }
     }
 }
 
-impl ProjectElement<Boolean> for BoxedMontyField {
+impl ProjectElementDynamic<Boolean> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &Boolean) -> Self::Element {
         self.project(value.inner())
     }
 }
 
-impl<const LIMBS: usize> ProjectElement<Int<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElementDynamic<Int<LIMBS>> for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn project(&self, value: &Int<LIMBS>) -> Self::Element {
         let abs: BoxedUint = value.inner().abs().into();
@@ -289,7 +289,7 @@ impl<const LIMBS: usize> ProjectElement<Int<LIMBS>> for BoxedMontyField {
     }
 }
 
-impl ProjectElement<BoxedUint> for BoxedMontyField {
+impl ProjectElementDynamic<BoxedUint> for BoxedMontyField {
     /// Convert the given integer into the Montgomery domain.
     fn project(&self, value: &BoxedUint) -> Self::Element {
         debug_assert_eq!(value.bits_precision(), self.bits_precision());
@@ -300,14 +300,14 @@ impl ProjectElement<BoxedUint> for BoxedMontyField {
     }
 }
 
-impl<const LIMBS: usize> ProjectElement<Uint<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElementDynamic<Uint<LIMBS>> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &Uint<LIMBS>) -> Self::Element {
         self.project(&BoxedUint::from(&value.0))
     }
 }
 
-impl<const LIMBS: usize> ProjectElement<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElementDynamic<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &crypto_bigint::Uint<LIMBS>) -> Self::Element {
         self.project(Uint::new_ref(value))
@@ -340,11 +340,11 @@ impl WithAssociatedInteger for BoxedMontyField {
     type Integer = BoxedUint;
 }
 
-impl LiftToIntegerDynamic for BoxedMontyField {
+impl LiftElementDynamic<<Self as WithAssociatedInteger>::Integer> for BoxedMontyField {
     /// Retrieves the integer currently encoded in this [`BoxedMontyField`],
     /// guaranteed to be reduced.
     #[inline(always)]
-    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
+    fn lift(&self, value: &Self::Element) -> Self::Integer {
         let mut out = BoxedUint::zero_with_precision(value.bits_precision());
         crypto_bigint_helpers::monty_retrieve_inner(
             value.0.as_limbs(),
@@ -415,7 +415,7 @@ mod tests {
             f.project(&2_u64),
             f.project(&123456789_u64),
         ] {
-            assert_eq!(f.project(&f.lift_to_integer(&x)), x);
+            assert_eq!(f.project(&f.lift(&x)), x);
         }
     }
 

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
-    IntRing, Wrapper, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int,
+    IntRing, Wrapper, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
+    crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
@@ -10,22 +11,32 @@ use crypto_bigint::{
 use num_traits::One;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[repr(transparent)]
 pub struct BoxedMontyField {
     pub params: BoxedMontyParams,
+    pub modulus_minus_one_div_two: BoxedUint,
 }
 
 impl BoxedMontyField {
     /// Creates a new [`BoxedMontyField`] from [`BoxedMontyParams`].
     #[inline(always)]
-    pub const fn wrap(params: BoxedMontyParams) -> Self {
-        Self { params }
+    #[allow(clippy::arithmetic_side_effects)] // False alert
+    pub fn wrap(params: BoxedMontyParams) -> Self {
+        let two = BoxedUint::from(2_u8).into_inner();
+        let two = two.as_nz_vartime().expect("Can't fail");
+        let modulus_minus_one_div_two =
+            (params.modulus().as_ref() - BoxedUint::one().into_inner()).div(two);
+        let modulus_minus_one_div_two = BoxedUint::new(modulus_minus_one_div_two);
+        Self {
+            params,
+            modulus_minus_one_div_two,
+        }
     }
 
     /// Unwrap the [`BoxedMontyForm`] into a field config and a field element.
+    #[inline(always)]
     pub fn unwrap_monty(el: BoxedMontyForm) -> (Self, BoxedUint) {
         let params = el.params().clone();
-        (Self { params }, BoxedUint::new(el.into_montgomery()))
+        (Self::wrap(params), BoxedUint::new(el.into_montgomery()))
     }
 
     /// Reassemble the `crypto-bigint`'s [`BoxedMontyForm`] from a raw
@@ -289,18 +300,25 @@ impl ProjectElement<BoxedUint> for BoxedMontyField {
     }
 }
 
-// impl<const LIMBS: usize> EncodeElement<crypto_bigint::Uint<LIMBS>> for
-// BoxedMontyField {     #[inline(always)]
-//     fn project(&self, value: &crypto_bigint::Uint<LIMBS>) -> Self::Element {
-//         self.project(Uint::new_ref(value))
-//     }
-// }
+impl<const LIMBS: usize> ProjectElement<Uint<LIMBS>> for BoxedMontyField {
+    #[inline(always)]
+    fn project(&self, value: &Uint<LIMBS>) -> Self::Element {
+        self.project(&BoxedUint::from(&value.0))
+    }
+}
+
+impl<const LIMBS: usize> ProjectElement<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
+    #[inline(always)]
+    fn project(&self, value: &crypto_bigint::Uint<LIMBS>) -> Self::Element {
+        self.project(Uint::new_ref(value))
+    }
+}
 
 //
 // Field stuff
 //
 
-impl FieldConfig for BoxedMontyField {
+impl BaseFieldConfig for BoxedMontyField {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
         let Some(modulus) = Odd::new(modulus.clone().into_inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
@@ -314,8 +332,7 @@ impl FieldConfig for BoxedMontyField {
 
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn modulus_minus_one_div_two(&self) -> Self::Integer {
-        let value = self.modulus();
-        (value - BoxedUint::one()) / BoxedUint::from(2_u8)
+        self.modulus_minus_one_div_two.clone()
     }
 }
 
@@ -357,7 +374,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
-        ensure_type_implements_trait!(F, FieldConfig);
+        ensure_type_implements_trait!(F, BaseFieldConfig);
     }
 
     //
@@ -715,7 +732,7 @@ mod tests {
     fn conversions() {
         let f = make_f();
 
-        // Test EncodeElement for BoxedUint
+        // Test ProjectElement for BoxedUint
         let u = BoxedUint::from(123_u64).resize(f.modulus().bits_precision());
         let a = f.project(&u);
         assert_eq!(a, f.project(&123_u64));

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -162,7 +162,7 @@ impl FieldConfigOps for BoxedMontyField {
 
         let r2 = BoxedUint::new_ref(self.params.as_ref().r2()).into();
         let x_inv = self.mul(&inverted, r2);
-        Some(self.mul(&x_inv, r2).into())
+        Some(self.mul(&x_inv, r2))
     }
 
     /// Montgomery multiplication `x*y/R mod m`, fully reduced.
@@ -183,9 +183,10 @@ impl FieldConfigOps for BoxedMontyField {
     }
 
     fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
-        crypto_bigint_helpers::pow::pow(
+        crypto_bigint_helpers::pow::pow_bounded_exp(
             &x.0,
             y.as_limbs(),
+            y.bits_precision(),
             BoxedUint::new(self.params.as_ref().one().clone()),
             BoxedUint::new_ref(self.params.modulus().as_ref()),
             self.params.as_ref().mod_neg_inv(),

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -5,7 +5,10 @@ use crate::{
     helpers::crypto_bigint as helpers,
 };
 use alloc::borrow::Cow;
-use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use core::{
+    cmp::Ordering,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+};
 use crypto_bigint::{
     MontyForm, Odd,
     modular::{BoxedMontyForm, BoxedMontyParams},
@@ -56,7 +59,7 @@ impl BoxedMontyField {
 
 /// A wrapper around [`BoxedUint`] to prevent accidentally calling math
 /// operations on it.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct BoxedMontyFieldElement(pub BoxedUint);
 
@@ -64,6 +67,20 @@ impl BoxedMontyFieldElement {
     #[inline(always)]
     pub fn bits_precision(&self) -> u32 {
         self.0.bits_precision()
+    }
+}
+
+/// Compares Montgomery form, not values.
+impl PartialOrd for BoxedMontyFieldElement {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Compares Montgomery form, not values.
+impl Ord for BoxedMontyFieldElement {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
     }
 }
 

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    IntRing, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int,
+    IntRing, Wrapper, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int,
 };
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
@@ -74,6 +74,34 @@ impl From<crypto_bigint::BoxedUint> for BoxedMontyFieldElement {
     #[inline(always)]
     fn from(value: crypto_bigint::BoxedUint) -> Self {
         Self(BoxedUint::new(value))
+    }
+}
+
+//
+// Wrapper
+//
+
+impl Wrapper for BoxedMontyFieldElement {
+    type Inner = BoxedUint;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
     }
 }
 
@@ -232,7 +260,7 @@ impl ProjectElement<bool> for BoxedMontyField {
 impl ProjectElement<Boolean> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &Boolean) -> Self::Element {
-        self.project(&value.inner())
+        self.project(value.inner())
     }
 }
 

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::{
-    IntRing, Wrapper, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
-    crypto_bigint_int::Int, crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
+    IntSemiring, IntSemiringConfig, LiftElementWithConfig, Wrapper, boolean::Boolean,
+    crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    helpers::crypto_bigint as helpers,
 };
 use alloc::borrow::Cow;
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
@@ -9,7 +10,7 @@ use crypto_bigint::{
     MontyForm, Odd,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
-use num_traits::One;
+use num_traits::{One, Signed};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BoxedMontyField {
@@ -131,9 +132,11 @@ impl Display for BoxedMontyField {
 // Field operations
 //
 
-impl FieldConfig for BoxedMontyField {
+impl SetConfig for BoxedMontyField {
     type Element = BoxedMontyFieldElement;
+}
 
+impl SemiringConfig for BoxedMontyField {
     fn is_zero(&self, value: &Self::Element) -> bool {
         value.0.is_zero()
     }
@@ -146,12 +149,6 @@ impl FieldConfig for BoxedMontyField {
         self.params.as_ref().one().clone().into()
     }
 
-    fn neg(&self, x: &Self::Element) -> Self::Element {
-        x.0.inner()
-            .neg_mod(self.params.modulus().as_nz_ref())
-            .into()
-    }
-
     fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
         x.0.inner()
             .add_mod(y.0.inner(), self.params.modulus().as_nz_ref())
@@ -162,19 +159,6 @@ impl FieldConfig for BoxedMontyField {
         x.0.inner()
             .sub_mod(y.0.inner(), self.params.modulus().as_nz_ref())
             .into()
-    }
-
-    fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
-        // Follows BoxedMontyForm::invert_vartime
-        let inverted: Option<crypto_bigint::BoxedUint> =
-            x.0.inner()
-                .invert_odd_mod_vartime(self.params.modulus())
-                .into();
-        let inverted = BoxedUint::new(inverted?).into();
-
-        let r2 = BoxedUint::new_ref(self.params.as_ref().r2()).into();
-        let x_inv = self.mul(&inverted, r2);
-        Some(self.mul(&x_inv, r2))
     }
 
     /// Montgomery multiplication `x*y/R mod m`, fully reduced.
@@ -194,18 +178,6 @@ impl FieldConfig for BoxedMontyField {
         out.into()
     }
 
-    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
-        helpers::pow::pow_bounded_exp(
-            &x.0,
-            y.as_limbs(),
-            y.bits_precision(),
-            BoxedUint::new(self.params.as_ref().one().clone()),
-            BoxedUint::new_ref(self.params.modulus().as_ref()),
-            self.params.as_ref().mod_neg_inv(),
-        )
-        .into()
-    }
-
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
         helpers::pow::pow_u32(
             &x.0,
@@ -215,6 +187,25 @@ impl FieldConfig for BoxedMontyField {
             self.params.as_ref().mod_neg_inv(),
         )
         .into()
+    }
+
+    // Modular arithmetic cannot overflow, so the checked variants always
+    // succeed.
+
+    fn checked_add(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.add(x, y))
+    }
+
+    fn checked_sub(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.sub(x, y))
+    }
+
+    fn checked_mul(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.mul(x, y))
+    }
+
+    fn checked_pow_u32(&self, x: &Self::Element, y: u32) -> Option<Self::Element> {
+        Some(self.pow_u32(x, y))
     }
 
     fn add_assign(&self, x: &mut Self::Element, y: &Self::Element) {
@@ -230,6 +221,65 @@ impl FieldConfig for BoxedMontyField {
     // Original mul_assign's implementation delegates to mul, so we stick to that
 }
 
+impl RingConfig for BoxedMontyField {
+    fn neg(&self, x: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .neg_mod(self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn checked_neg(&self, x: &Self::Element) -> Option<Self::Element> {
+        Some(self.neg(x))
+    }
+}
+
+impl IntSemiringConfig for BoxedMontyField {
+    // Parity is a property of the represented residue, so it requires leaving
+    // the Montgomery domain.
+
+    fn is_odd(&self, x: &Self::Element) -> bool {
+        IntSemiring::is_odd(&self.lift(x))
+    }
+
+    fn is_even(&self, x: &Self::Element) -> bool {
+        IntSemiring::is_even(&self.lift(x))
+    }
+}
+
+impl WithExtensionDegree for BoxedMontyField {
+    #[inline(always)]
+    fn extension_degree() -> u64 {
+        1
+    }
+}
+
+impl FieldConfig for BoxedMontyField {
+    fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
+        // Follows BoxedMontyForm::invert_vartime
+        let inverted: Option<crypto_bigint::BoxedUint> =
+            x.0.inner()
+                .invert_odd_mod_vartime(self.params.modulus())
+                .into();
+        let inverted = BoxedUint::new(inverted?).into();
+
+        let r2 = BoxedUint::new_ref(self.params.as_ref().r2()).into();
+        let x_inv = self.mul(&inverted, r2);
+        Some(self.mul(&x_inv, r2))
+    }
+
+    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
+        helpers::pow::pow_bounded_exp(
+            &x.0,
+            y.as_limbs(),
+            y.bits_precision(),
+            BoxedUint::new(self.params.as_ref().one().clone()),
+            BoxedUint::new_ref(self.params.modulus().as_ref()),
+            self.params.as_ref().mod_neg_inv(),
+        )
+        .into()
+    }
+}
+
 //
 // Conversions
 //
@@ -237,7 +287,7 @@ impl FieldConfig for BoxedMontyField {
 macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
-            impl ProjectElementDynamic<$t> for BoxedMontyField {
+            impl ProjectElementWithConfig<$t> for BoxedMontyField {
                 fn project(&self, value: &$t) -> Self::Element {
                     let abs: BoxedUint = value.into();
                     self.project(&abs.resize(self.modulus().bits_precision()))
@@ -250,7 +300,7 @@ macro_rules! impl_from_unsigned {
 macro_rules! impl_from_signed {
     ($($t:ty),* $(,)?) => {
         $(
-            impl ProjectElementDynamic<$t> for BoxedMontyField {
+            impl ProjectElementWithConfig<$t> for BoxedMontyField {
                 fn project(&self, value: &$t) -> Self::Element {
                     let magnitude = BoxedUint::from(value.abs_diff(0)).resize(self.modulus().bits_precision());
                     let magnitude = self.project(&magnitude);
@@ -264,20 +314,20 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
-impl ProjectElementDynamic<bool> for BoxedMontyField {
+impl ProjectElementWithConfig<bool> for BoxedMontyField {
     fn project(&self, value: &bool) -> Self::Element {
         if *value { self.one() } else { self.zero() }
     }
 }
 
-impl ProjectElementDynamic<Boolean> for BoxedMontyField {
+impl ProjectElementWithConfig<Boolean> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &Boolean) -> Self::Element {
         self.project(value.inner())
     }
 }
 
-impl<const LIMBS: usize> ProjectElementDynamic<Int<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElementWithConfig<Int<LIMBS>> for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn project(&self, value: &Int<LIMBS>) -> Self::Element {
         let abs: BoxedUint = value.inner().abs().into();
@@ -290,7 +340,7 @@ impl<const LIMBS: usize> ProjectElementDynamic<Int<LIMBS>> for BoxedMontyField {
     }
 }
 
-impl ProjectElementDynamic<BoxedUint> for BoxedMontyField {
+impl ProjectElementWithConfig<BoxedUint> for BoxedMontyField {
     /// Convert the given integer into the Montgomery domain.
     fn project(&self, value: &BoxedUint) -> Self::Element {
         use crypto_bigint::Resize;
@@ -319,14 +369,14 @@ impl ProjectElementDynamic<BoxedUint> for BoxedMontyField {
     }
 }
 
-impl<const LIMBS: usize> ProjectElementDynamic<Uint<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElementWithConfig<Uint<LIMBS>> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &Uint<LIMBS>) -> Self::Element {
         self.project(&BoxedUint::from(&value.0))
     }
 }
 
-impl<const LIMBS: usize> ProjectElementDynamic<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElementWithConfig<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
     #[inline(always)]
     fn project(&self, value: &crypto_bigint::Uint<LIMBS>) -> Self::Element {
         self.project(Uint::new_ref(value))
@@ -359,11 +409,11 @@ impl WithAssociatedInteger for BoxedMontyField {
     type Integer = BoxedUint;
 }
 
-impl LiftElementDynamic<<Self as WithAssociatedInteger>::Integer> for BoxedMontyField {
+impl LiftElementWithConfig<<Self as WithAssociatedInteger>::Integer> for BoxedMontyField {
     /// Retrieves the integer currently encoded in this [`BoxedMontyField`],
     /// guaranteed to be reduced.
     #[inline(always)]
-    fn lift(&self, value: &Self::Element) -> Self::Integer {
+    fn lift(&self, value: &Self::Element) -> <Self as WithAssociatedInteger>::Integer {
         let mut out = BoxedUint::zero_with_precision(value.bits_precision());
         helpers::monty_retrieve_inner(
             value.0.as_limbs(),

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,32 +1,79 @@
 use super::*;
 use crate::{
-    IntRing, Semiring, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
-    crypto_bigint_int::Int,
+    IntRing, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int,
 };
-use core::{
-    cmp::Ordering,
-    fmt::{Debug, Display, Formatter, Result as FmtResult},
-    hash::{Hash, Hasher},
-    iter::{Product, Sum},
-    ops::{Add, AddAssign, DivAssign, Mul, MulAssign, Sub, SubAssign},
-};
+use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
-    Odd,
+    MontyForm, Odd,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
-use crypto_primitives_proc_macros::InfallibleCheckedOp;
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, One, Pow};
+use num_traits::One;
 
-#[derive(Clone, PartialEq, Eq, InfallibleCheckedOp)]
-#[infallible_checked_unary_op((CheckedNeg, neg))]
-#[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct BoxedMontyField(BoxedMontyForm);
+pub struct BoxedMontyField {
+    pub params: BoxedMontyParams,
+}
 
 impl BoxedMontyField {
-    /// Creates a new `BoxedMontyField` from a `BoxedMontyForm`.
-    pub const fn new(form: BoxedMontyForm) -> Self {
-        Self(form)
+    /// Creates a new [`BoxedMontyField`] from [`BoxedMontyParams`].
+    #[inline(always)]
+    pub const fn wrap(params: BoxedMontyParams) -> Self {
+        Self { params }
+    }
+
+    /// Unwrap the [`BoxedMontyForm`] into a field config and a field element.
+    pub fn unwrap_monty(el: BoxedMontyForm) -> (Self, BoxedUint) {
+        let params = el.params().clone();
+        (Self { params }, BoxedUint::new(el.into_montgomery()))
+    }
+
+    /// Reassemble the `crypto-bigint`'s [`BoxedMontyForm`] from a raw
+    /// Montgomery value.
+    #[inline(always)]
+    pub fn form(&self, el: &BoxedMontyFieldElement) -> BoxedMontyForm {
+        BoxedMontyForm::from_montgomery(el.0.inner().clone(), &self.params)
+    }
+
+    #[inline(always)]
+    pub fn bits_precision(&self) -> u32 {
+        self.params.bits_precision()
+    }
+}
+
+/// A wrapper around [`BoxedUint`] to prevent accidentally calling math
+/// operations on it.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct BoxedMontyFieldElement(pub BoxedUint);
+
+impl BoxedMontyFieldElement {
+    #[inline(always)]
+    pub fn bits_precision(&self) -> u32 {
+        self.0.bits_precision()
+    }
+}
+
+impl From<BoxedUint> for BoxedMontyFieldElement {
+    #[inline(always)]
+    fn from(value: BoxedUint) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&BoxedUint> for &BoxedMontyFieldElement {
+    #[inline(always)]
+    fn from(value: &BoxedUint) -> Self {
+        // Safety: BoxedMontyFieldElement is #[repr(transparent)] and is guaranteed to
+        // have the same memory layout.
+        unsafe { &*(value as *const BoxedUint as *const BoxedMontyFieldElement) }
+    }
+}
+
+impl From<crypto_bigint::BoxedUint> for BoxedMontyFieldElement {
+    #[inline(always)]
+    fn from(value: crypto_bigint::BoxedUint) -> Self {
+        Self(BoxedUint::new(value))
     }
 }
 
@@ -34,265 +81,114 @@ impl BoxedMontyField {
 // Core traits
 //
 
-impl Debug for BoxedMontyField {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Debug::fmt(&self.0, f)
-    }
-}
-
 impl Display for BoxedMontyField {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(
-            f,
-            "{} (mod {})",
-            self.0.retrieve(),
-            self.0.params().modulus()
+        write!(f, "F_{}", self.params.modulus())
+    }
+}
+
+//
+// Field operations
+//
+
+impl FieldConfigOps for BoxedMontyField {
+    type Element = BoxedMontyFieldElement;
+
+    fn is_zero(&self, value: &Self::Element) -> bool {
+        value.0.is_zero()
+    }
+
+    fn zero(&self) -> Self::Element {
+        BoxedUint::zero_with_precision(self.params.bits_precision()).into()
+    }
+
+    fn one(&self) -> Self::Element {
+        self.params.as_ref().one().clone().into()
+    }
+
+    fn neg(&self, x: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .neg_mod(self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .add_mod(y.0.inner(), self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .sub_mod(y.0.inner(), self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
+        // Follows BoxedMontyForm::invert_vartime
+        let inverted: Option<crypto_bigint::BoxedUint> =
+            x.0.inner()
+                .invert_odd_mod_vartime(self.params.modulus())
+                .into();
+        let inverted = BoxedUint::new(inverted?).into();
+
+        let r2 = BoxedUint::new_ref(self.params.as_ref().r2()).into();
+        let x_inv = self.mul(&inverted, r2);
+        Some(self.mul(&x_inv, r2).into())
+    }
+
+    /// Montgomery multiplication `x*y/R mod m`, fully reduced.
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        // Note: CIOS multiplication is worse for this
+        let modulus = BoxedUint::new_ref(self.params.modulus().as_ref());
+        let mut out = BoxedUint::zero_with_precision(self.bits_precision());
+        let carry = crypto_bigint_helpers::mul::monty_mul_limbs(
+            x.0.as_limbs(),
+            y.0.as_limbs(),
+            out.as_mut_limbs(),
+            modulus.as_limbs(),
+            self.params.as_ref().mod_neg_inv(),
+        );
+
+        out.sub_assign_mod_with_carry(carry, modulus, modulus);
+        out.into()
+    }
+
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
+        crypto_bigint_helpers::pow::pow_u32(
+            &x.0,
+            y,
+            BoxedUint::new(self.params.as_ref().one().clone()),
+            BoxedUint::new_ref(self.params.modulus().as_ref()),
+            self.params.as_ref().mod_neg_inv(),
         )
+        .into()
     }
-}
 
-impl PartialOrd for BoxedMontyField {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.cfg().modulus() != other.cfg().modulus() {
-            return None;
-        }
-        Some(Ord::cmp(self.0.as_montgomery(), other.0.as_montgomery()))
+    fn add_assign(&self, x: &mut Self::Element, y: &Self::Element) {
+        x.0.inner_mut()
+            .add_mod_assign(y.0.inner(), self.params.modulus().as_nz_ref());
     }
-}
 
-impl Hash for BoxedMontyField {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_montgomery().as_limbs().hash(state)
+    fn sub_assign(&self, x: &mut Self::Element, y: &Self::Element) {
+        let modulus_ref = BoxedUint::new_ref(self.params.modulus().as_ref());
+        x.0.sub_assign_mod_with_carry(crypto_bigint::Limb::ZERO, &y.0, modulus_ref);
     }
-}
 
-//
-// Basic arithmetic operations
-//
-
-impl Neg for BoxedMontyField {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self(self.0.neg())
-    }
-}
-
-macro_rules! impl_basic_op_boilerplate {
-    ($trait:ident, $method:ident) => {
-        impl $trait for BoxedMontyField {
-            type Output = Self;
-
-            #[inline(always)]
-            fn $method(self, rhs: Self) -> Self::Output {
-                (&self).$method(&rhs)
-            }
-        }
-
-        impl $trait<&Self> for BoxedMontyField {
-            type Output = Self;
-
-            #[inline(always)]
-            fn $method(self, rhs: &Self) -> Self::Output {
-                (&self).$method(rhs)
-            }
-        }
-
-        impl $trait<BoxedMontyField> for &BoxedMontyField {
-            type Output = BoxedMontyField;
-
-            #[inline(always)]
-            fn $method(self, rhs: BoxedMontyField) -> Self::Output {
-                self.$method(&rhs)
-            }
-        }
-    };
-}
-
-macro_rules! impl_basic_op_forward {
-    ($trait:ident, $method:ident) => {
-        impl $trait for &BoxedMontyField {
-            type Output = BoxedMontyField;
-
-            #[inline(always)]
-            fn $method(self, rhs: Self) -> Self::Output {
-                BoxedMontyField(BoxedMontyForm::$method(&self.0, &rhs.0))
-            }
-        }
-    };
-}
-
-impl_basic_op_boilerplate!(Add, add);
-impl_basic_op_boilerplate!(Sub, sub);
-impl_basic_op_boilerplate!(Mul, mul);
-impl_basic_op_boilerplate!(Div, div);
-
-impl_basic_op_forward!(Add, add);
-impl_basic_op_forward!(Sub, sub);
-impl_basic_op_forward!(Mul, mul); // Note: CIOS multiplication is worse for this
-
-impl Div for &BoxedMontyField {
-    type Output = BoxedMontyField;
-
-    #[inline(always)]
-    fn div(self, rhs: &BoxedMontyField) -> Self::Output {
-        self.checked_div(rhs).expect("Division by zero")
-    }
-}
-
-impl Pow<u32> for BoxedMontyField {
-    type Output = Self;
-
-    fn pow(self, rhs: u32) -> Self::Output {
-        Self(self.0.pow(BoxedUint::from(rhs).inner()))
-    }
-}
-
-impl Inv for BoxedMontyField {
-    type Output = Option<Self>;
-
-    fn inv(self) -> Self::Output {
-        Some(Self(Option::from(self.0.invert_vartime())?))
-    }
-}
-
-impl Inv for &BoxedMontyField {
-    type Output = Option<BoxedMontyField>;
-
-    fn inv(self) -> Self::Output {
-        Some(BoxedMontyField(Option::from(self.0.invert_vartime())?))
-    }
-}
-
-//
-// Checked arithmetic operations
-// (Note: Field operations do not overflow)
-//
-
-impl CheckedDiv for BoxedMontyField {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn checked_div(&self, rhs: &Self) -> Option<Self> {
-        Some(self * rhs.inv()?)
-    }
-}
-
-//
-// Arithmetic assign operations
-//
-
-macro_rules! impl_op_assign {
-    ($trait:ident, $method:ident, $inner:ident) => {
-        impl $trait for BoxedMontyField {
-            #[inline(always)]
-            fn $method(&mut self, rhs: Self) {
-                *self = (&*self).$inner(&rhs);
-            }
-        }
-        impl $trait<&Self> for BoxedMontyField {
-            #[inline(always)]
-            fn $method(&mut self, rhs: &Self) {
-                *self = (&*self).$inner(rhs);
-            }
-        }
-    };
-}
-
-impl_op_assign!(AddAssign, add_assign, add);
-impl_op_assign!(SubAssign, sub_assign, sub);
-impl_op_assign!(MulAssign, mul_assign, mul);
-
-impl DivAssign for BoxedMontyField {
-    fn div_assign(&mut self, rhs: Self) {
-        self.div_assign(&rhs);
-    }
-}
-
-impl DivAssign<&Self> for BoxedMontyField {
-    fn div_assign(&mut self, rhs: &Self) {
-        self.0.mul_assign(rhs.0.invert().expect("Division by zero"))
-    }
-}
-
-//
-// Aggregate operations
-//
-
-impl Sum for BoxedMontyField {
-    fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
-        let Some(BoxedMontyField(first)) = iter.next() else {
-            panic!("Sum of an empty iterator is not defined for BoxedMontyField");
-        };
-        Self(iter.fold(first, |acc, x| BoxedMontyForm::add(&acc, &x.0)))
-    }
-}
-
-impl<'a> Sum<&'a Self> for BoxedMontyField {
-    fn sum<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
-        let Some(BoxedMontyField(first)) = iter.next() else {
-            panic!("Sum of an empty iterator is not defined for BoxedMontyField");
-        };
-        Self(iter.fold(first.clone(), |acc, x| BoxedMontyForm::add(&acc, &x.0)))
-    }
-}
-
-impl Product for BoxedMontyField {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn product<I: Iterator<Item = Self>>(mut iter: I) -> Self {
-        let Some(first) = iter.next() else {
-            panic!("Product of an empty iterator is not defined for BoxedMontyField");
-        };
-        iter.fold(first, |acc, x| acc * x)
-    }
-}
-
-impl<'a> Product<&'a Self> for BoxedMontyField {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn product<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
-        let Some(first) = iter.next() else {
-            panic!("Product of an empty iterator is not defined for BoxedMontyField");
-        };
-        iter.fold(first.clone(), |acc, x| acc * x)
-    }
+    // Original mul_assign's implementation delegates to mul, so we stick to that
 }
 
 //
 // Conversions
 //
 
-impl From<BoxedMontyForm> for BoxedMontyField {
-    #[inline(always)]
-    fn from(value: BoxedMontyForm) -> Self {
-        Self(value)
-    }
-}
-
-impl From<BoxedMontyField> for BoxedMontyForm {
-    #[inline(always)]
-    fn from(value: BoxedMontyField) -> Self {
-        value.0
-    }
-}
-
-impl From<&BoxedMontyField> for BoxedMontyField {
-    fn from(value: &Self) -> Self {
-        value.clone()
-    }
-}
-
 macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
-            impl FromWithConfig<$t> for BoxedMontyField {
-                fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
+            impl ProjectElement<$t> for BoxedMontyField {
+                fn project(&self, value: &$t) -> Self::Element {
                     let abs: BoxedUint = value.into();
-                    let abs = abs.resize(cfg.modulus().bits_precision());
-                    Self(BoxedMontyForm::new(abs.into_inner(), cfg))
-                }
-            }
-
-            impl FromWithConfig<&$t> for BoxedMontyField {
-                fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
-                    Self::from_with_cfg(*value, cfg)
+                    self.project(&abs.resize(self.modulus().bits_precision()))
                 }
             }
         )*
@@ -302,18 +198,11 @@ macro_rules! impl_from_unsigned {
 macro_rules! impl_from_signed {
     ($($t:ty),* $(,)?) => {
         $(
-            #[allow(clippy::arithmetic_side_effects)] // False alert
-            impl FromWithConfig<$t> for BoxedMontyField {
-                fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
-                    let magnitude = BoxedUint::from(value.abs_diff(0)).resize(cfg.modulus().bits_precision());
-                    let form = BoxedMontyForm::new(magnitude.into_inner(), cfg);
-                    Self(if value.is_negative() { -form } else { form })
-                }
-            }
-
-            impl FromWithConfig<&$t> for BoxedMontyField {
-                fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
-                    Self::from_with_cfg(*value, cfg)
+            impl ProjectElement<$t> for BoxedMontyField {
+                fn project(&self, value: &$t) -> Self::Element {
+                    let magnitude = BoxedUint::from(value.abs_diff(0)).resize(self.modulus().bits_precision());
+                    let magnitude = self.project(&magnitude);
+                    if value.is_negative() { self.neg(&magnitude) } else { magnitude }
                 }
             }
         )*
@@ -323,174 +212,94 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
-impl FromWithConfig<bool> for BoxedMontyField {
-    fn from_with_cfg(value: bool, cfg: &Self::Config) -> Self {
-        let magnitude: BoxedUint = if value {
-            BoxedUint::one()
-        } else {
-            BoxedUint::zero()
-        };
-        let magnitude = magnitude.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(magnitude.into_inner(), cfg))
+impl ProjectElement<bool> for BoxedMontyField {
+    fn project(&self, value: &bool) -> Self::Element {
+        if *value { self.one() } else { self.zero() }
     }
 }
 
-impl FromWithConfig<&bool> for BoxedMontyField {
-    fn from_with_cfg(value: &bool, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(*value, cfg)
+impl ProjectElement<Boolean> for BoxedMontyField {
+    #[inline(always)]
+    fn project(&self, value: &Boolean) -> Self::Element {
+        self.project(&value.inner())
     }
 }
 
-impl FromWithConfig<Boolean> for BoxedMontyField {
-    fn from_with_cfg(value: Boolean, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(*value, cfg)
-    }
-}
-
-impl FromWithConfig<&Boolean> for BoxedMontyField {
-    fn from_with_cfg(value: &Boolean, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(*value, cfg)
-    }
-}
-
-impl<const LIMBS: usize> FromWithConfig<Int<LIMBS>> for BoxedMontyField {
-    fn from_with_cfg(value: Int<LIMBS>, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(&value, cfg)
-    }
-}
-
-impl<const LIMBS: usize> FromWithConfig<&Int<LIMBS>> for BoxedMontyField {
+impl<const LIMBS: usize> ProjectElement<Int<LIMBS>> for BoxedMontyField {
     #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn from_with_cfg(value: &Int<LIMBS>, cfg: &Self::Config) -> Self {
+    fn project(&self, value: &Int<LIMBS>) -> Self::Element {
         let abs: BoxedUint = value.inner().abs().into();
-        let abs = abs.resize(cfg.modulus().bits_precision());
-
-        let result = Self(BoxedMontyForm::new(abs.into_inner(), cfg));
-
-        if value.is_negative() { -result } else { result }
+        let abs = self.project(&abs.resize(self.modulus().bits_precision()));
+        if value.is_negative() {
+            self.neg(&abs)
+        } else {
+            abs
+        }
     }
 }
 
-impl FromWithConfig<BoxedUint> for BoxedMontyField {
-    fn from_with_cfg(value: BoxedUint, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(&value, cfg)
-    }
-}
-
-impl FromWithConfig<&BoxedUint> for BoxedMontyField {
-    fn from_with_cfg(value: &BoxedUint, cfg: &Self::Config) -> Self {
-        let value = value.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(value.into_inner(), cfg))
-    }
-}
-
-impl<const LIMBS: usize> FromWithConfig<crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
-    fn from_with_cfg(value: crypto_bigint::Uint<LIMBS>, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(&value, cfg)
-    }
-}
-
-impl<const LIMBS: usize> FromWithConfig<&crypto_bigint::Uint<LIMBS>> for BoxedMontyField {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn from_with_cfg(value: &crypto_bigint::Uint<LIMBS>, cfg: &Self::Config) -> Self {
-        let value: BoxedUint = value.into();
-        let value = value.resize(cfg.modulus().bits_precision());
-        Self(BoxedMontyForm::new(value.into_inner(), cfg))
-    }
-}
-
-//
-// Semiring, Ring and Field
-//
-
-impl Semiring for BoxedMontyField {}
-
-impl Ring for BoxedMontyField {}
-
-impl Field for BoxedMontyField {
-    type Inner = BoxedUint;
-    type Integer = BoxedUint;
-
-    #[inline(always)]
-    fn inner(&self) -> &Self::Inner {
-        BoxedUint::new_ref(self.0.as_montgomery())
-    }
-
-    #[inline(always)]
-    fn inner_mut(&mut self) -> &mut Self::Inner {
-        // TODO: address this once possible.
-        unimplemented!(
-            "For now we keep this unimplemented. \
-            The method was introduced in crypto-bigint in this PR:\
-            https://github.com/RustCrypto/crypto-bigint/pull/1014\
-            but not yet available in the latest RC from the craits.io."
+impl ProjectElement<BoxedUint> for BoxedMontyField {
+    /// Convert the given integer into the Montgomery domain.
+    fn project(&self, value: &BoxedUint) -> Self::Element {
+        debug_assert_eq!(value.bits_precision(), self.bits_precision());
+        self.mul(
+            value.into(),
+            BoxedUint::new_ref(self.params.as_ref().r2()).into(),
         )
     }
-
-    #[inline(always)]
-    fn into_inner(self) -> Self::Inner {
-        BoxedUint::new(self.0.to_montgomery())
-    }
-
-    #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
-        BoxedUint::new(self.0.retrieve())
-    }
 }
 
-impl HasPrimeFieldConfig for BoxedMontyField {
-    type Config = BoxedMontyParams;
+// impl<const LIMBS: usize> EncodeElement<crypto_bigint::Uint<LIMBS>> for
+// BoxedMontyField {     #[inline(always)]
+//     fn project(&self, value: &crypto_bigint::Uint<LIMBS>) -> Self::Element {
+//         self.project(Uint::new_ref(value))
+//     }
+// }
 
-    fn cfg(&self) -> &Self::Config {
-        self.0.params()
-    }
-}
+//
+// Field stuff
+//
 
-impl PrimeField for BoxedMontyField {
-    fn modulus(cfg: &Self::Config) -> Self::Integer {
-        BoxedUint::new(cfg.modulus().clone().get())
-    }
-
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn modulus_minus_one_div_two(cfg: &Self::Config) -> Self::Inner {
-        let value = BoxedUint::new(cfg.modulus().clone().get());
-        (value - BoxedUint::one()) / BoxedUint::from(2_u8)
-    }
-
-    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
+impl FieldConfig for BoxedMontyField {
+    fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
         let Some(modulus) = Odd::new(modulus.clone().into_inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
         };
-        Ok(BoxedMontyParams::new(modulus))
+        Ok(Self::wrap(BoxedMontyParams::new(modulus)))
     }
 
-    fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::from_montgomery(inner.into_inner(), cfg))
+    fn modulus(&self) -> Self::Integer {
+        BoxedUint::new(self.params.modulus().clone().get())
     }
 
-    fn is_zero(value: &Self) -> bool {
-        value.0.is_zero().into()
-    }
-
-    fn zero_with_cfg(cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::zero(cfg))
-    }
-
-    fn one_with_cfg(cfg: &Self::Config) -> Self {
-        Self(BoxedMontyForm::one(cfg))
+    #[allow(clippy::arithmetic_side_effects)] // False alert
+    fn modulus_minus_one_div_two(&self) -> Self::Integer {
+        let value = self.modulus();
+        (value - BoxedUint::one()) / BoxedUint::from(2_u8)
     }
 }
 
-//
-// Zeroize
-//
+impl WithAssociatedInteger for BoxedMontyField {
+    type Integer = BoxedUint;
+}
 
-#[cfg(feature = "zeroize")]
-impl zeroize::Zeroize for BoxedMontyField {
-    fn zeroize(&mut self) {
-        self.0.zeroize()
+impl LiftToIntegerDynamic for BoxedMontyField {
+    /// Retrieves the integer currently encoded in this [`BoxedMontyField`],
+    /// guaranteed to be reduced.
+    #[inline(always)]
+    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
+        let mut out = BoxedUint::zero_with_precision(value.bits_precision());
+        crypto_bigint_helpers::monty_retrieve_inner(
+            value.0.as_limbs(),
+            out.as_mut_limbs(),
+            self.modulus().as_limbs(),
+            self.params.as_ref().mod_neg_inv(),
+        );
+        out
     }
 }
+
+// TODO: Do we want to zeroize the modulus?
 
 #[allow(
     clippy::arithmetic_side_effects,
@@ -502,20 +311,20 @@ mod tests {
     use super::*;
     use crate::ensure_type_implements_trait;
     use alloc::vec;
-    use num_traits::Pow;
+    use core::cmp::Ordering;
 
     type F = BoxedMontyField;
 
     #[test]
-    fn ensure_blanket_traits() {
-        // NB: this ensures `PrimeField` implementation too!
-        ensure_type_implements_trait!(F, FromPrimitiveWithConfig);
+    fn ensure_traits() {
+        ensure_type_implements_trait!(F, FieldConfig);
     }
 
     //
     // Test helpers
     //
-    fn test_config() -> BoxedMontyParams {
+
+    fn make_f() -> F {
         // Using a 256-bit prime 2^256 - 2^32 - 977 (secp256k1 field prime)
         let modulus = BoxedUint::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
@@ -523,28 +332,12 @@ mod tests {
         )
         .unwrap();
         let modulus = Odd::new(modulus.into_inner()).expect("modulus should be odd");
-        BoxedMontyParams::new(modulus)
-    }
-
-    fn from_u64(value: u64) -> F {
-        F::from_with_cfg(value, &test_config())
-    }
-
-    fn from_i64(value: i64) -> F {
-        F::from_with_cfg(value, &test_config())
-    }
-
-    fn zero() -> F {
-        F::zero_with_cfg(&test_config())
-    }
-
-    fn one() -> F {
-        F::one_with_cfg(&test_config())
+        F::wrap(BoxedMontyParams::new(modulus))
     }
 
     #[test]
-    fn new_with_cfg_correct() {
-        let cfg = test_config();
+    fn encoding() {
+        let f = make_f();
 
         // `modulus + 1` should reduce to one.
         let x = BoxedUint::from_be_hex(
@@ -552,156 +345,133 @@ mod tests {
             256,
         )
         .unwrap();
-        assert_eq!(F::from_with_cfg(x, &cfg), F::one_with_cfg(&cfg));
+        assert_eq!(f.project(&x), f.one());
 
         // `modulus` itself should reduce to zero.
-        let modulus = F::modulus(&cfg);
-        assert_eq!(F::from_with_cfg(modulus, &cfg), F::zero_with_cfg(&cfg));
+        let modulus = F::modulus(&f);
+        assert_eq!(f.project(&modulus), f.zero());
 
         // Lifting to integer and projecting back yields the original element.
         for x in [
-            F::zero_with_cfg(&cfg),
-            F::one_with_cfg(&cfg),
-            F::from_with_cfg(2_u64, &cfg),
-            F::from_with_cfg(123456789_u64, &cfg),
+            f.zero(),
+            f.one(),
+            f.project(&2_u64),
+            f.project(&123456789_u64),
         ] {
-            assert_eq!(F::from_with_cfg(x.lift_to_integer(), &cfg), x);
+            assert_eq!(f.project(&f.lift_to_integer(&x)), x);
         }
     }
 
     #[test]
     fn zero_one_basics() {
-        let z = zero();
-        assert!(F::is_zero(&z));
-        let o = one();
-        assert!(!F::is_zero(&o));
+        let f = make_f();
+        let z = f.zero();
+        assert!(f.is_zero(&z));
+        let o = f.one();
+        assert!(!f.is_zero(&o));
         assert_ne!(z, o);
     }
 
     #[test]
     fn basic_operations() {
-        // Negation
-        let a = from_u64(9);
-        let neg_a = -a.clone();
-        assert_eq!(&a + &neg_a, zero());
+        let f = make_f();
 
-        let a = from_u64(10);
-        let b = from_u64(5);
+        // Negation
+        let a = f.project(&9);
+        let neg_a = f.neg(&a);
+        assert_eq!(f.add(&a, &neg_a), f.zero());
+
+        let a = f.project(&10);
+        let b = f.project(&5);
 
         // Addition
-        let c = a.clone() + b.clone();
-        assert_eq!(c, from_u64(15));
+        let c = f.add(&a, &b);
+        assert_eq!(c, f.project(&15));
 
         // Subtraction
-        let d = a.clone() - b.clone();
-        assert_eq!(d, from_u64(5));
+        let d = f.sub(&a, &b);
+        assert_eq!(d, f.project(&5));
 
         // Multiplication
-        let e = a.clone() * b.clone();
-        assert_eq!(e, from_u64(50));
+        let e = f.mul(&a, &b);
+        assert_eq!(e, f.project(&50));
 
         // Division
-        let num = from_u64(11);
-        let den = from_u64(5);
-        let q = num.clone() / den.clone();
-        assert_eq!(&q * &den, num);
+        let num = f.project(&11);
+        let den = f.project(&5);
+        let q = f.div(&num, &den);
+        assert_eq!(f.mul(&q, &den), num);
     }
 
     #[test]
     fn basic_operations_overflow() {
-        let params = test_config();
-        let mod_minus_one = BoxedUint::new(params.modulus().as_ref().clone()) - BoxedUint::one();
-        let mod_minus_one = F::from_with_cfg(mod_minus_one, &params);
+        let f = make_f();
+
+        let mod_minus_one = f.modulus() - BoxedUint::one();
+        let mod_minus_one = f.project(&mod_minus_one);
 
         // Negation
-        let res = -mod_minus_one.clone();
-        assert_eq!(res, one());
+        let res = f.neg(&mod_minus_one);
+        assert_eq!(res, f.one());
 
         // Addition
-        let res = mod_minus_one.clone() + one();
-        assert_eq!(res, zero());
+        let res = f.add(&mod_minus_one, &f.one());
+        assert_eq!(res, f.zero());
 
         // Subtraction
-        let res = zero() - one();
+        let res = f.sub(&f.zero(), &f.one());
         assert_eq!(res, mod_minus_one);
 
         // Multiplication
-        let res = mod_minus_one.clone() * from_u64(2);
-        assert_eq!(res, mod_minus_one.clone() - one());
+        let res = f.mul(&mod_minus_one, &f.project(&2));
+        assert_eq!(res, f.sub(&mod_minus_one, &f.one()));
 
-        let res = mod_minus_one.clone() * mod_minus_one.clone();
-        assert_eq!(res, one());
+        let res = f.mul(&mod_minus_one, &mod_minus_one);
+        assert_eq!(res, f.one());
 
         // Division
-        let res = one() / mod_minus_one.clone();
+        let res = f.div(&f.one(), &mod_minus_one);
         assert_eq!(res, mod_minus_one);
     }
 
     #[test]
     fn add_wrapping() {
-        let a = from_i64(-100);
-        let b = from_u64(105);
-        let c = a + b;
-        let d = from_u64(5);
+        let f = make_f();
+
+        let a = f.project(&-100);
+        let b = f.project(&105);
+        let c = f.add(&a, &b);
+        let d = f.project(&5);
         assert_eq!(c, d);
-    }
-
-    #[allow(clippy::op_ref)]
-    #[test]
-    fn reference_operations() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        // Addition
-        let c = &a + &b;
-        assert_eq!(c, from_u64(15));
-
-        // Subtraction
-        let d = &a - &b;
-        assert_eq!(d, from_u64(5));
-
-        // Multiplication
-        let e = &a * &b;
-        assert_eq!(e, from_u64(50));
-
-        // Division
-        let num = from_u64(11);
-        let den = from_u64(5);
-        let q = &num / &den;
-        assert_eq!(&q * &den, num);
     }
 
     #[test]
     fn from_bool() {
-        let cfg = test_config();
-        assert_eq!(F::from_with_cfg(true, &cfg), one());
-        assert_eq!(F::from_with_cfg(false, &cfg), zero());
+        let f = make_f();
 
-        let t = F::from_with_cfg(true, &cfg);
-        let f = F::from_with_cfg(false, &cfg);
-        assert_eq!(t, one());
-        assert_eq!(f, zero());
+        assert_eq!(f.project(&true), f.one());
+        assert_eq!(f.project(&false), f.zero());
     }
 
     #[test]
     fn from_unsigned_and_signed() {
-        let cfg = {
+        let f = {
             // Using a 64-bit prime 10064419296686275259
             let modulus = BoxedUint::from_be_hex("8bac0006d9927abb", 64).unwrap();
             let modulus = Odd::new(modulus.into_inner()).expect("modulus should be odd");
-            BoxedMontyParams::new(modulus)
+            F::wrap(BoxedMontyParams::new(modulus))
         };
         macro_rules! to_field {
             ($x:expr) => {
-                F::from_with_cfg($x, &cfg)
+                f.project(&$x)
             };
         }
-        let zero = F::zero_with_cfg(&cfg);
-        let one = F::one_with_cfg(&cfg);
+        let zero = f.zero();
+        let one = f.one();
         assert_eq!(to_field!(0), zero);
         assert_eq!(to_field!(1), one);
-        assert_eq!(to_field!(-1) + one, zero);
-        assert_eq!(to_field!(-5) + F::from_with_cfg(5, &cfg), zero);
+        assert_eq!(f.add(&to_field!(-1), &one), zero);
+        assert_eq!(f.add(&to_field!(-5), &f.project(&5)), zero);
 
         // u64 maximum value (hand-calculated)
         assert_eq!(
@@ -723,310 +493,207 @@ mod tests {
 
         // Verify property: i64::MIN + |i64::MIN| = 0
         let i64_min_abs = to_field!(i64::MIN.unsigned_abs());
-        assert_eq!(to_field!(i64::MIN) + i64_min_abs, zero);
+        assert_eq!(f.add(&to_field!(i64::MIN), &i64_min_abs), zero);
     }
 
     #[test]
     fn assign_operations() {
+        let f = make_f();
+
         // Addition
-        let mut a = from_u64(5);
-        a += from_u64(6);
-        assert_eq!(a, from_u64(11));
+        let mut a = f.project(&5);
+        f.add_assign(&mut a, &f.project(&6));
+        assert_eq!(a, f.project(&11));
 
         // Subtraction
-        let mut a = from_u64(20);
-        a -= from_u64(7);
-        assert_eq!(a, from_u64(13));
+        let mut a = f.project(&20);
+        f.sub_assign(&mut a, &f.project(&7));
+        assert_eq!(a, f.project(&13));
 
         // Multiplication
-        let mut a = from_u64(11);
-        a *= from_u64(3);
-        assert_eq!(a, from_u64(33));
+        let mut a = f.project(&11);
+        f.mul_assign(&mut a, &f.project(&3));
+        assert_eq!(a, f.project(&33));
 
         // Division
-        let mut a = from_u64(20);
-        let b = from_u64(4);
-        a /= b;
-        assert_eq!(&a * &from_u64(4), from_u64(20));
+        let mut a = f.project(&20);
+        let b = f.project(&4);
+        f.div_assign(&mut a, &b);
+        assert_eq!(f.mul(&a, &b), f.project(&20));
     }
 
     #[test]
     #[should_panic(expected = "Division by zero")]
     fn div_by_zero_panics() {
-        let a = from_u64(7);
-        let zero = zero();
-        let _ = a / zero;
+        let f = make_f();
+
+        let a = f.project(&7);
+        let zero = f.zero();
+        let _ = f.div(&a, &zero);
     }
 
     #[test]
     fn pow_operation() {
+        let f = make_f();
+
         // Test basic exponentiation
-        let base = from_u64(2);
+        let base = f.project(&2);
 
         // 2^0 = 1
-        assert_eq!(base.clone().pow(0), one());
+        assert_eq!(f.pow_u32(&base, 0), f.one());
 
         // 2^1 = 2
-        assert_eq!(base.clone().pow(1), base);
+        assert_eq!(f.pow_u32(&base, 1), base);
 
         // 2^3 = 8
-        assert_eq!(base.clone().pow(3), from_u64(8));
+        assert_eq!(f.pow_u32(&base, 3), f.project(&8));
 
         // 2^10 = 1024
-        assert_eq!(base.clone().pow(10), from_u64(1024));
+        assert_eq!(f.pow_u32(&base, 10), f.project(&1024));
 
         // Test with different base
-        let base = from_u64(3);
+        let base = f.project(&3);
 
         // 3^4 = 81
-        assert_eq!(base.clone().pow(4), from_u64(81));
+        assert_eq!(f.pow_u32(&base, 4), f.project(&81));
 
         // Test with base 1
-        let base = one();
-        assert_eq!(base.clone().pow(1000), one());
+        let base = f.one();
+        assert_eq!(f.pow_u32(&base, 1000), f.one());
 
         // Test with base 0
-        let base = zero();
-        assert_eq!(base.clone().pow(0), one()); // 0^0 = 1 by convention
-        assert_eq!(base.clone().pow(10), zero()); // 0^n = 0 for n > 0
+        let base = f.zero();
+        assert_eq!(f.pow_u32(&base, 0), f.one()); // 0^0 = 1 by convention
+        assert_eq!(f.pow_u32(&base, 10), f.zero()); // 0^n = 0 for n > 0
+    }
+
+    #[test]
+    fn pow_matches_crypto_bigint() {
+        let f = make_f();
+
+        for (base, exp) in [
+            (0_u64, 0_u32),
+            (0, 7),
+            (1, 1000),
+            (2, 10),
+            (3, 251),
+            (123456789, 1),
+            (123456789, u32::MAX),
+        ] {
+            let x = f.project(&base);
+            let expected = BoxedMontyForm::from_montgomery(x.0.inner().clone(), &f.params)
+                .pow(&crypto_bigint::BoxedUint::from(u64::from(exp)));
+            assert_eq!(
+                f.pow_u32(&x, exp).0.inner(),
+                expected.as_montgomery(),
+                "{base}^{exp} diverges from BoxedMontyForm::pow"
+            );
+        }
     }
 
     #[test]
     fn inv_operation() {
-        let a = from_u64(5);
-        let inv_a = a.clone().inv().unwrap();
-        assert_eq!(&a * &inv_a, one());
+        let f = make_f();
+
+        let a = f.project(&5);
+        let inv_a = f.inv(&a).unwrap();
+        assert_eq!(f.mul(&a, &inv_a), f.one());
 
         // Test that zero has no inverse
-        let zero = zero();
-        assert!(zero.inv().is_none());
-    }
-
-    #[test]
-    fn checked_neg() {
-        // Test with positive number
-        let a = from_u64(10);
-        let neg_a = a.checked_neg().unwrap();
-        assert_eq!(neg_a, from_i64(-10));
-
-        // Test with negative number
-        let b = from_i64(-5);
-        let neg_b = b.checked_neg().unwrap();
-        assert_eq!(neg_b, from_u64(5));
-
-        // Test with zero
-        let zero_val = zero();
-        let neg_zero = zero_val.checked_neg().unwrap();
-        assert_eq!(neg_zero, zero());
-    }
-
-    #[test]
-    fn checked_add() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        let c = a.checked_add(&b).unwrap();
-        assert_eq!(c, from_u64(15));
-    }
-
-    #[test]
-    fn checked_sub() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        let d = a.checked_sub(&b).unwrap();
-        assert_eq!(d, from_u64(5));
-    }
-
-    #[test]
-    fn checked_mul() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        let e = a.checked_mul(&b).unwrap();
-        assert_eq!(e, from_u64(50));
+        let zero = f.zero();
+        assert!(f.inv(&zero).is_none());
     }
 
     #[test]
     fn checked_div() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-        let zero = zero();
+        let f = make_f();
+
+        let a = f.project(&10);
+        let b = f.project(&5);
+        let zero = f.zero();
 
         // Normal division
-        let c = a.checked_div(&b).unwrap();
-        assert_eq!(&c * &b, a);
+        let c = f.checked_div(&a, &b).unwrap();
+        assert_eq!(f.mul(&c, &b), a);
 
         // Division by zero
-        assert!(a.checked_div(&zero).is_none());
-    }
-
-    #[allow(clippy::op_ref)]
-    #[test]
-    fn ref_and_value_combinations_add_sub_mul() {
-        let a = from_u64(42);
-        let b = from_u64(123);
-
-        let r1 = &a + &b;
-        let a1 = from_u64(42);
-        let b1 = from_u64(123);
-        let r2 = a1 + b1;
-        let a2 = from_u64(42);
-        let b2 = from_u64(123);
-        let r3 = a2 + &b2;
-        let a3 = from_u64(42);
-        let b3 = from_u64(123);
-        let r4 = &a3 + b3;
-        assert_eq!(r1, r2);
-        assert_eq!(r1, r3);
-        assert_eq!(r1, r4);
-
-        let a = from_u64(88);
-        let b = from_u64(59);
-        let s1 = &a - &b;
-        let a1 = from_u64(88);
-        let b1 = from_u64(59);
-        let s2 = a1 - b1;
-        let a2 = from_u64(88);
-        let b2 = from_u64(59);
-        let s3 = a2 - &b2;
-        let a3 = from_u64(88);
-        let b3 = from_u64(59);
-        let s4 = &a3 - b3;
-        assert_eq!(s1, s2);
-        assert_eq!(s1, s3);
-        assert_eq!(s1, s4);
-
-        let a = from_u64(9);
-        let b = from_u64(14);
-        let m1 = &a * &b;
-        let a1 = from_u64(9);
-        let b1 = from_u64(14);
-        let m2 = a1 * b1;
-        let a2 = from_u64(9);
-        let b2 = from_u64(14);
-        let m3 = a2 * &b2;
-        let a3 = from_u64(9);
-        let b3 = from_u64(14);
-        let m4 = &a3 * b3;
-        assert_eq!(m1, m2);
-        assert_eq!(m1, m3);
-        assert_eq!(m1, m4);
-    }
-
-    #[test]
-    fn assign_ops_with_refs_and_val() {
-        let mut a = from_u64(100);
-        let b = from_u64(50);
-        a += b;
-        assert_eq!(a, from_u64(150));
-
-        let mut c = from_u64(100);
-        let d = from_u64(50);
-        c += &d;
-        assert_eq!(c, from_u64(150));
-
-        let mut e = from_u64(100);
-        let f = from_u64(30);
-        e -= f;
-        assert_eq!(e, from_u64(70));
-
-        let mut g = from_u64(100);
-        let h = from_u64(30);
-        g -= &h;
-        assert_eq!(g, from_u64(70));
-
-        let mut i = from_u64(10);
-        let j = from_u64(5);
-        i *= j;
-        assert_eq!(i, from_u64(50));
-
-        let mut k = from_u64(10);
-        let l = from_u64(5);
-        k *= &l;
-        assert_eq!(k, from_u64(50));
+        assert!(f.checked_div(&a, &zero).is_none());
     }
 
     #[test]
     fn aggregate_operations() {
-        // Sum
-        let values = vec![from_u64(1), from_u64(2), from_u64(3)];
-        let sum: F = values.iter().sum();
-        assert_eq!(sum, from_u64(6));
+        let f = make_f();
 
-        let sum2: F = values.into_iter().sum();
-        assert_eq!(sum2, from_u64(6));
+        // Sum
+        let values = vec![f.project(&1), f.project(&2), f.project(&3)];
+        let sum = f.sum_refs(values.iter());
+        assert_eq!(sum, f.project(&6));
+
+        let sum2 = f.sum(values.into_iter());
+        assert_eq!(sum2, f.project(&6));
 
         // Product
-        let values = vec![from_u64(2), from_u64(3), from_u64(4)];
-        let product: F = values.iter().product();
-        assert_eq!(product, from_u64(24));
+        let values = vec![f.project(&2), f.project(&3), f.project(&4)];
+        let product = f.product_refs(values.iter());
+        assert_eq!(product, f.project(&24));
 
-        let product2: F = values.into_iter().product();
-        assert_eq!(product2, from_u64(24));
+        let product2 = f.product(values.into_iter());
+        assert_eq!(product2, f.project(&24));
 
-        // Test empty collections panic
-        // Note: BoxedMontyField doesn't have a default config, so empty
-        // iterators must panic
+        // Empty iterators yield the respective identity elements
+        assert_eq!(f.sum(core::iter::empty()), f.zero());
+        assert_eq!(f.product(core::iter::empty()), f.one());
     }
 
     #[test]
     fn conversions() {
-        let cfg = test_config();
+        let f = make_f();
 
-        // Test FromWithConfig for BoxedUint
-        let u: BoxedUint = BoxedUint::from(123_u64);
-        let f = F::from_with_cfg(u, &cfg);
-        assert_eq!(f, from_u64(123));
-
-        // Test inner() and cfg()
-        let value = from_u64(456);
-        let _inner_ref = value.inner();
-        let _cfg_ref = value.cfg();
+        // Test EncodeElement for BoxedUint
+        let u = BoxedUint::from(123_u64).resize(f.modulus().bits_precision());
+        let a = f.project(&u);
+        assert_eq!(a, f.project(&123_u64));
     }
 
     #[test]
     fn from_primitive() {
-        let cfg = test_config();
+        let f = make_f();
 
-        // Test FromWithConfig for various types
-        let a = F::from_with_cfg(42_u8, &cfg);
-        assert_eq!(a, from_u64(42));
+        // Unsigned types
+        assert_eq!(f.project(&42_u8), f.project(&42_u64));
+        assert_eq!(f.project(&12345_u16), f.project(&12345_u64));
+        assert_eq!(f.project(&1234567890_u32), f.project(&1234567890_u64));
+        assert_eq!(
+            f.project(&1234567890123456789_u64),
+            f.project(&1234567890123456789_u128)
+        );
 
-        let b = F::from_with_cfg(12345_u16, &cfg);
-        assert_eq!(b, from_u64(12345));
-
-        let c = F::from_with_cfg(1234567890_u32, &cfg);
-        assert_eq!(c, from_u64(1234567890));
-
-        let d = F::from_with_cfg(1234567890123456789_u64, &cfg);
-        assert_eq!(d, from_u64(1234567890123456789));
-
-        let e = F::from_with_cfg(-42_i8, &cfg);
-        assert_eq!(e, from_i64(-42));
-
-        let f = F::from_with_cfg(-12345_i16, &cfg);
-        assert_eq!(f, from_i64(-12345));
-
-        let g = F::from_with_cfg(-1234567_i32, &cfg);
-        assert_eq!(g, from_i64(-1234567));
-
-        let h = F::from_with_cfg(-1234567890123456789_i64, &cfg);
-        assert_eq!(h, from_i64(-1234567890123456789));
+        // Signed types
+        assert_eq!(f.project(&-42_i8), f.project(&-42_i64));
+        assert_eq!(f.project(&-12345_i16), f.project(&-12345_i64));
+        assert_eq!(f.project(&-1234567_i32), f.project(&-1234567_i64));
+        assert_eq!(
+            f.project(&-1234567890123456789_i64),
+            f.project(&-1234567890123456789_i128)
+        );
     }
 
     #[test]
     fn clone_works() {
-        let a = from_u64(42);
+        let f = make_f();
+
+        let a = f.project(&42);
         let b = a.clone();
         assert_eq!(a, b);
     }
 
     #[test]
     fn equality_and_ordering() {
-        let a = from_u64(10);
-        let b = from_u64(10);
-        let c = from_u64(20);
+        let f = make_f();
+
+        let a = f.project(&10);
+        let b = f.project(&10);
+        let c = f.project(&20);
 
         // Test equality
         assert_eq!(a, b);
@@ -1041,7 +708,7 @@ mod tests {
         assert!(a >= b);
 
         // Verify transitivity of ordering
-        let d = from_u64(30);
+        let d = f.project(&30);
         if a < c && c < d {
             assert!(a < d);
         }
@@ -1068,8 +735,10 @@ mod tests {
             }
         }
 
-        let a = from_u64(42);
-        let b = from_u64(42);
+        let f = make_f();
+
+        let a = f.project(&42);
+        let b = f.project(&42);
 
         let mut hasher_a = TestHasher { state: 0 };
         a.hash(&mut hasher_a);
@@ -1087,42 +756,41 @@ mod tests {
 
     #[test]
     fn prime_field_methods() {
-        let a = from_u64(42);
-        let cfg = a.cfg();
+        let f = make_f();
 
         // Test that we can get modulus
-        let modulus = F::modulus(cfg);
+        let modulus = f.modulus();
         assert!(modulus.bits_precision() > 0);
 
         // Test modulus_minus_one_div_two
-        let m_minus_1_div_2 = F::modulus_minus_one_div_two(cfg);
+        let m_minus_1_div_2 = f.modulus_minus_one_div_two();
         assert!(m_minus_1_div_2.bits_precision() > 0);
 
-        // Test zero_with_cfg and one_with_cfg
-        let z = F::zero_with_cfg(cfg);
-        assert!(F::is_zero(&z));
-        let o = F::one_with_cfg(cfg);
-        assert!(!F::is_zero(&o));
+        // Test zero and one
+        let z = f.zero();
+        assert!(f.is_zero(&z));
+        let o = f.one();
+        assert!(!f.is_zero(&o));
     }
 
     #[test]
-    fn make_cfg_works() {
+    fn new_works() {
         let modulus = BoxedUint::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
             256,
         )
         .unwrap();
-        let cfg = F::make_cfg(&modulus).expect("Should create config");
+        let f = F::new(&modulus).expect("Should create config");
 
         // Create a field element using this config
-        let a = F::from_with_cfg(123_u64, &cfg);
-        assert_eq!(a, from_u64(123));
+        let a = f.project(&123_u64);
+        assert_eq!(a, f.project(&123));
     }
 
     #[test]
-    fn make_cfg_rejects_even_modulus() {
+    fn new_rejects_even_modulus() {
         let even_modulus = BoxedUint::from(42_u64);
-        let result = F::make_cfg(&even_modulus);
+        let result = F::new(&even_modulus);
         assert!(result.is_err());
     }
 }

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -247,7 +247,6 @@ impl IntSemiringConfig for BoxedMontyField {
 }
 
 impl WithExtensionDegree for BoxedMontyField {
-    #[inline(always)]
     fn extension_degree() -> u64 {
         1
     }
@@ -422,6 +421,17 @@ impl LiftElementWithConfig<<Self as WithAssociatedInteger>::Integer> for BoxedMo
             self.params.as_ref().mod_neg_inv(),
         );
         out
+    }
+}
+
+//
+// Zeroize
+//
+
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for BoxedMontyFieldElement {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
     }
 }
 

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -3,6 +3,7 @@ use crate::{
     IntRing, Wrapper, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
     crypto_bigint_int::Int, crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
+use alloc::borrow::Cow;
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
     MontyForm, Odd,
@@ -292,9 +293,27 @@ impl<const LIMBS: usize> ProjectElementDynamic<Int<LIMBS>> for BoxedMontyField {
 impl ProjectElementDynamic<BoxedUint> for BoxedMontyField {
     /// Convert the given integer into the Montgomery domain.
     fn project(&self, value: &BoxedUint) -> Self::Element {
-        debug_assert_eq!(value.bits_precision(), self.bits_precision());
+        use crypto_bigint::Resize;
+
+        let value = if value.bits_precision() < self.bits_precision() {
+            Cow::Owned(value.resize(self.bits_precision()))
+        } else if value.bits_precision() > self.bits_precision() {
+            // The value is wider than the modulus: reduce it first, so that
+            // the resize below cannot truncate.
+            let modulus = self
+                .params
+                .modulus()
+                .as_ref()
+                .resize(value.bits_precision());
+            let modulus = modulus.into_nz().expect("modulus should be non-zero");
+            let rem = value.0.rem_vartime(&modulus);
+            Cow::Owned(BoxedUint::new(rem).resize(self.bits_precision()))
+        } else {
+            Cow::Borrowed(value)
+        };
+
         self.mul(
-            value.into(),
+            value.as_ref().into(),
             BoxedUint::new_ref(self.params.as_ref().r2()).into(),
         )
     }
@@ -674,6 +693,41 @@ mod tests {
         );
     }
 
+    /// Regression test: the final AMM value of the exponentiation can land in
+    /// `[modulus, 2*modulus)`, where exactly one final conditional subtraction
+    /// is needed. `almost_montgomery_reduce` used to apply a stale comparison
+    /// to both subtractions, subtracting the modulus twice and wrapping.
+    #[test]
+    fn pow_amm_final_reduction() {
+        let f = {
+            // Using a 64-bit prime 10064419296686275259
+            let modulus = BoxedUint::from_be_hex("8bac0006d9927abb", 64).unwrap();
+            let modulus = Odd::new(modulus.into_inner()).expect("modulus should be odd");
+            F::wrap(BoxedMontyParams::new(modulus))
+        };
+
+        // Small cases with hand-checkable results
+        for (base, exp, result) in [(2_u64, 8_u32, 256_u64), (2, 9, 512), (3, 5, 243)] {
+            assert_eq!(
+                f.pow_u32(&f.project(&base), exp),
+                f.project(&result),
+                "{base}^{exp} != {result}"
+            );
+        }
+
+        // Larger cases, verified against the library
+        for (base, exp) in [(12345_u64, 67_u32), (2, 64), (123456789, u32::MAX)] {
+            let x = f.project(&base);
+            let expected = BoxedMontyForm::from_montgomery(x.0.inner().clone(), &f.params)
+                .pow(&crypto_bigint::BoxedUint::from(u64::from(exp)));
+            assert_eq!(
+                f.pow_u32(&x, exp).0.inner(),
+                expected.as_montgomery(),
+                "{base}^{exp} diverges from BoxedMontyForm::pow"
+            );
+        }
+    }
+
     #[test]
     fn inv_operation() {
         let f = make_f();
@@ -736,6 +790,23 @@ mod tests {
         let u = BoxedUint::from(123_u64).resize(f.modulus().bits_precision());
         let a = f.project(&u);
         assert_eq!(a, f.project(&123_u64));
+
+        // A BoxedUint narrower than the field is zero-extended...
+        let narrow = BoxedUint::from(123_u64); // 64-bit precision
+        assert_eq!(f.project(&narrow), f.project(&123_u64));
+
+        // ...including when it arrives via the fixed-width Uint projections.
+        assert_eq!(f.project(&Uint::<1>::from(123_u64)), f.project(&123_u64));
+
+        // A BoxedUint wider than the field is reduced, not truncated:
+        // 2^256 mod (2^256 - 2^32 - 977) = 2^32 + 977 (truncation would give 0)
+        let wide = BoxedUint::from_be_hex(
+            "0000000000000000000000000000000000000000000000000000000000000001\
+             0000000000000000000000000000000000000000000000000000000000000000",
+            512,
+        )
+        .unwrap();
+        assert_eq!(f.project(&wide), f.project(&0x1_000003D1_u64));
     }
 
     #[test]

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -425,6 +425,30 @@ impl LiftElementWithConfig<<Self as WithAssociatedInteger>::Integer> for BoxedMo
 }
 
 //
+// Serialization and Deserialization
+//
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for BoxedMontyFieldElement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        BoxedUint::deserialize(deserializer).map(Self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for BoxedMontyFieldElement {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+//
 // Zeroize
 //
 

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     IntSemiring, Semiring, Wrapper, boolean::Boolean, crypto_bigint_int::Int,
-    crypto_bigint_uint::Uint,
+    crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
 use core::{
     cmp::Ordering,
@@ -325,7 +325,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> SubAssign<&Self> for ConstMontyFiel
 impl<Mod: Params<LIMBS>, const LIMBS: usize> MulAssign<&Self> for ConstMontyField<Mod, LIMBS> {
     #[inline(always)]
     fn mul_assign(&mut self, rhs: &Self) {
-        let monty_mul = crypto_bigint_helpers::mul::monty_mul(
+        let monty_mul = helpers::mul::monty_mul(
             self.0.as_montgomery(),
             rhs.0.as_montgomery(),
             Mod::PARAMS.modulus().as_ref(),
@@ -410,7 +410,7 @@ macro_rules! impl_from_unsigned {
             impl<Mod: Params<LIMBS>, const LIMBS: usize> From<$t> for ConstMontyField<Mod, LIMBS> {
                 fn from(value: $t) -> Self {
                     let value = Uint::from(value);
-                    let monty_mul = crypto_bigint_helpers::mul::monty_mul(
+                    let monty_mul = helpers::mul::monty_mul(
                         value.inner(),
                         Mod::PARAMS.r2(),
                         Mod::PARAMS.modulus().as_ref(),
@@ -436,7 +436,7 @@ macro_rules! impl_from_signed {
                 #![allow(clippy::arithmetic_side_effects)]
                 fn from(value: $t) -> Self {
                     let magnitude = Uint::from(value.abs_diff(0));
-                    let monty_mul = crypto_bigint_helpers::mul::monty_mul(
+                    let monty_mul = helpers::mul::monty_mul(
                         magnitude.inner(),
                         Mod::PARAMS.r2(),
                         Mod::PARAMS.modulus().as_ref(),
@@ -484,7 +484,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> From<Uint<LIMBS>> for ConstMontyFie
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&Uint<LIMBS>> for ConstMontyField<Mod, LIMBS> {
     fn from(value: &Uint<LIMBS>) -> Self {
-        let monty_mul = crypto_bigint_helpers::mul::monty_mul(
+        let monty_mul = helpers::mul::monty_mul(
             value.inner(),
             Mod::PARAMS.r2(),
             Mod::PARAMS.modulus().as_ref(),
@@ -529,11 +529,8 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&crypto_b
         let value = value.resize();
         // Note: abs() returns Uint so it's guaranteed to fit
         let abs = value.abs();
-        let monty_mul = crypto_bigint_helpers::mul::monty_mul(
-            &abs,
-            Mod::PARAMS.r2(),
-            Mod::PARAMS.modulus().as_ref(),
-        );
+        let monty_mul =
+            helpers::mul::monty_mul(&abs, Mod::PARAMS.r2(), Mod::PARAMS.modulus().as_ref());
         let result = ConstMontyField(ConstMontyForm::from_montgomery(monty_mul));
         if value.is_negative().into() {
             -result
@@ -746,7 +743,8 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Retrieve for ConstMontyField<Mod, L
 // Predefined fields of various sizes for convenience
 //
 
-pub type F64<Mod> = ConstMontyField<Mod, { crypto_bigint::U64::LIMBS }>;
+use helpers::WORD_FACTOR;
+pub type F64<Mod> = ConstMontyField<Mod, { WORD_FACTOR }>;
 pub type F128<Mod> = ConstMontyField<Mod, { 2 * WORD_FACTOR }>;
 pub type F192<Mod> = ConstMontyField<Mod, { 3 * WORD_FACTOR }>;
 pub type F256<Mod> = ConstMontyField<Mod, { 4 * WORD_FACTOR }>;

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{Semiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use crate::{
+    IntRing, IntSemiring, Semiring, boolean::Boolean, crypto_bigint_int::Int,
+    crypto_bigint_uint::Uint,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -16,6 +19,7 @@ use crypto_primitives_proc_macros::InfallibleCheckedOp;
 use num_traits::{
     CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
 };
+use pastey::paste;
 
 #[cfg(feature = "rand")]
 use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
@@ -196,7 +200,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Neg for ConstMontyField<Mod, LIMBS>
 }
 
 macro_rules! impl_basic_op_forward_to_assign {
-    ($trait:ident, $method:ident, $assign_method:ident) => {
+    ($trait:ident, $method:ident, $assign_method:ident) => { paste! {
         impl<Mod: Params<LIMBS>, const LIMBS: usize> $trait for ConstMontyField<Mod, LIMBS> {
             type Output = ConstMontyField<Mod, LIMBS>;
 
@@ -211,7 +215,7 @@ macro_rules! impl_basic_op_forward_to_assign {
 
             #[inline(always)]
             fn $method(mut self, rhs: &ConstMontyField<Mod, LIMBS>) -> Self::Output {
-                self.$assign_method(rhs);
+                [<$trait Assign>]::$assign_method(&mut self, rhs);
                 self
             }
         }
@@ -235,7 +239,7 @@ macro_rules! impl_basic_op_forward_to_assign {
                 self.clone().$method(rhs)
             }
         }
-    };
+    }};
 }
 
 impl_basic_op_forward_to_assign!(Add, add, add_assign);
@@ -267,7 +271,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Inv for ConstMontyField<Mod, LIMBS>
 impl<Mod: Params<LIMBS>, const LIMBS: usize> CheckedDiv for ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn checked_div(&self, rhs: &Self) -> Option<Self> {
-        Some(self * rhs.inv()?)
+        Some(self * Inv::inv(*rhs)?)
     }
 }
 
@@ -326,7 +330,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> MulAssign<&Self> for ConstMontyFiel
 impl<Mod: Params<LIMBS>, const LIMBS: usize> DivAssign<&Self> for ConstMontyField<Mod, LIMBS> {
     #[inline(always)]
     fn div_assign(&mut self, rhs: &Self) {
-        self.mul_assign(rhs.inv().expect("Division by zero"));
+        self.mul_assign(Inv::inv(*rhs).expect("Division by zero"));
     }
 }
 
@@ -548,11 +552,24 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstSemiring for ConstMontyField<M
     const MIN: Self = Self::ZERO;
 }
 
+impl<Mod: Params<LIMBS>, const LIMBS: usize> IntSemiring for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
+    fn is_odd(&self) -> bool {
+        // There's no way to check that efficiently
+        self.lift_to_integer().is_odd()
+    }
+
+    #[inline(always)]
+    fn is_even(&self) -> bool {
+        // There's no way to check that efficiently
+        self.lift_to_integer().is_even()
+    }
+}
+
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Ring for ConstMontyField<Mod, LIMBS> {}
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMBS> {
+impl<Mod: Params<LIMBS>, const LIMBS: usize> FixedField for ConstMontyField<Mod, LIMBS> {
     type Inner = Uint<LIMBS>;
-    type Integer = Uint<LIMBS>;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -570,14 +587,14 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Field for ConstMontyField<Mod, LIMB
     }
 
     #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
-        Uint::new(self.0.retrieve())
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(ConstMontyForm::from_montgomery(inner.into_inner()))
     }
 }
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstPrimeField for ConstMontyField<Mod, LIMBS> {
+impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstBaseField for ConstMontyField<Mod, LIMBS> {
     const MODULUS: Self::Integer = *Uint::new_ref(Mod::PARAMS.modulus().as_ref());
-    const MODULUS_MINUS_ONE_DIV_TWO: Self::Inner = {
+    const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = {
         let m_minus_one = CBUint::wrapping_sub(Self::MODULUS.inner(), &CBUint::ONE);
         let two = CBUint::<LIMBS>::wrapping_add(&CBUint::ONE, &CBUint::ONE);
         Uint::new(CBUint::wrapping_div(
@@ -585,10 +602,16 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstPrimeField for ConstMontyField
             &NonZeroUint::new_unwrap(two),
         ))
     };
+}
 
+impl<Mod: Params<LIMBS>, const LIMBS: usize> WithAssociatedInteger for ConstMontyField<Mod, LIMBS> {
+    type Integer = Uint<LIMBS>;
+}
+
+impl<Mod: Params<LIMBS>, const LIMBS: usize> LiftToIntegerStatic for ConstMontyField<Mod, LIMBS> {
     #[inline(always)]
-    fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(ConstMontyForm::from_montgomery(inner.into_inner()))
+    fn lift_to_integer(&self) -> Self::Integer {
+        Uint::new(self.0.retrieve())
     }
 }
 
@@ -739,7 +762,7 @@ pub type F32768<Mod> = ConstMontyField<Mod, { 512 * WORD_FACTOR }>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ensure_type_implements_trait;
+    use crate::{ConstIntRing, FixedBaseField, ensure_type_implements_trait};
     use crypto_bigint::{Square, U64, U256, const_monty_params};
     use num_traits::{One, Zero};
 
@@ -752,9 +775,9 @@ mod tests {
     type F = ConstMontyField<ModP, { U256::LIMBS }>;
 
     #[test]
-    fn ensure_blanket_traits() {
-        // NB: this ensures `PrimeField` implementation too!
-        ensure_type_implements_trait!(F, FromPrimitiveWithConfig);
+    fn ensure_traits() {
+        ensure_type_implements_trait!(F, ConstIntRing);
+        ensure_type_implements_trait!(F, ConstBaseField);
     }
 
     #[test]
@@ -765,7 +788,7 @@ mod tests {
         ));
         assert_eq!(F::new(x), F::one());
 
-        assert_eq!(F::from(<F as PrimeField>::modulus(&())), F::zero());
+        assert_eq!(F::from(<F as FixedBaseField>::modulus()), F::zero());
 
         // Lifting to integer and projecting back yields the original element.
         for x in [F::zero(), F::one(), F::from(2_u64), F::from(123456789_u64)] {
@@ -777,10 +800,8 @@ mod tests {
     fn zero_one_basics() {
         let z = F::zero();
         assert!(z.is_zero());
-        assert!(PrimeField::is_zero(&z));
         let o = F::one();
         assert!(!o.is_zero());
-        assert!(!PrimeField::is_zero(&o));
         assert_ne!(z, o);
     }
 

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    IntRing, IntSemiring, Semiring, boolean::Boolean, crypto_bigint_int::Int,
+    IntRing, IntSemiring, Semiring, Wrapper, boolean::Boolean, crypto_bigint_int::Int,
     crypto_bigint_uint::Uint,
 };
 use core::{
@@ -28,7 +28,7 @@ use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 #[infallible_checked_unary_op((CheckedNeg, neg))]
 #[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
 #[repr(transparent)]
-pub struct ConstMontyField<Mod: Params<LIMBS>, const LIMBS: usize>(ConstMontyForm<Mod, LIMBS>);
+pub struct ConstMontyField<Mod: Params<LIMBS>, const LIMBS: usize>(pub ConstMontyForm<Mod, LIMBS>);
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::cast_possible_truncation)] // Guaranteed to fit due to crypto_bigint::Uint
@@ -37,22 +37,12 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
 
     #[inline(always)]
     pub const fn new(value: Uint<LIMBS>) -> Self {
-        Self(ConstMontyForm::new(value.inner()))
+        Self(ConstMontyForm::new(&value.0))
     }
 
     #[inline(always)]
     pub const fn new_unchecked(inner: Uint<LIMBS>) -> Self {
-        Self(ConstMontyForm::from_montgomery(inner.into_inner()))
-    }
-
-    #[inline(always)]
-    pub const fn inner(&self) -> &Uint<LIMBS> {
-        Uint::new_ref(self.0.as_montgomery())
-    }
-
-    #[inline(always)]
-    pub const fn into_inner(self) -> Uint<LIMBS> {
-        Uint::new(self.0.to_montgomery())
+        Self(ConstMontyForm::from_montgomery(inner.0))
     }
 
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`],
@@ -73,7 +63,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
 
     /// Create a `ConstMontyForm` from a value in Montgomery form.
     pub const fn from_montgomery(integer: Uint<LIMBS>) -> Self {
-        Self(ConstMontyForm::from_montgomery(integer.into_inner()))
+        Self(ConstMontyForm::from_montgomery(integer.0))
     }
 
     /// Extract the value from the `ConstMontyForm` in Montgomery form.
@@ -97,7 +87,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
         exponent: &Uint<RHS_LIMBS>,
         exponent_bits: u32,
     ) -> Self {
-        Self(self.0.pow_bounded_exp(exponent.inner(), exponent_bits))
+        Self(self.0.pow_bounded_exp(&exponent.0, exponent_bits))
     }
 }
 
@@ -554,6 +544,34 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&crypto_b
 }
 
 //
+// Wrapper
+//
+
+impl<Mod: Params<LIMBS>, const LIMBS: usize> Wrapper for ConstMontyField<Mod, LIMBS> {
+    type Inner = Uint<LIMBS>;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        Uint::new_ref(self.0.as_montgomery())
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        Uint::new_ref_mut(self.0.as_montgomery_mut())
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        Uint::new(self.0.to_montgomery())
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(ConstMontyForm::from_montgomery(inner.into_inner()))
+    }
+}
+
+//
 // Semiring, Ring and Field
 //
 
@@ -585,34 +603,12 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> IntSemiring for ConstMontyField<Mod
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Ring for ConstMontyField<Mod, LIMBS> {}
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> FixedField for ConstMontyField<Mod, LIMBS> {
-    type Inner = Uint<LIMBS>;
-
-    #[inline(always)]
-    fn inner(&self) -> &Self::Inner {
-        Uint::new_ref(self.0.as_montgomery())
-    }
-
-    #[inline(always)]
-    fn inner_mut(&mut self) -> &mut Self::Inner {
-        Uint::new_ref_mut(self.0.as_montgomery_mut())
-    }
-
-    #[inline(always)]
-    fn into_inner(self) -> Self::Inner {
-        Uint::new(self.0.to_montgomery())
-    }
-
-    #[inline(always)]
-    fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(ConstMontyForm::from_montgomery(inner.into_inner()))
-    }
-}
+impl<Mod: Params<LIMBS>, const LIMBS: usize> FixedField for ConstMontyField<Mod, LIMBS> {}
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstBaseField for ConstMontyField<Mod, LIMBS> {
     const MODULUS: Self::Integer = *Uint::new_ref(Mod::PARAMS.modulus().as_ref());
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = {
-        let m_minus_one = CBUint::wrapping_sub(Self::MODULUS.inner(), &CBUint::ONE);
+        let m_minus_one = CBUint::wrapping_sub(&Self::MODULUS.0, &CBUint::ONE);
         let two = CBUint::<LIMBS>::wrapping_add(&CBUint::ONE, &CBUint::ONE);
         Uint::new(CBUint::wrapping_div(
             &m_minus_one,
@@ -793,6 +789,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(F, Wrapper);
         ensure_type_implements_trait!(F, ConstIntRing);
         ensure_type_implements_trait!(F, ConstBaseField);
     }

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -591,13 +591,13 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> IntSemiring for ConstMontyField<Mod
     #[inline(always)]
     fn is_odd(&self) -> bool {
         // There's no way to check that efficiently
-        self.lift_to_integer().is_odd()
+        self.lift().is_odd()
     }
 
     #[inline(always)]
     fn is_even(&self) -> bool {
         // There's no way to check that efficiently
-        self.lift_to_integer().is_even()
+        self.lift().is_even()
     }
 }
 
@@ -621,9 +621,11 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> WithAssociatedInteger for ConstMont
     type Integer = Uint<LIMBS>;
 }
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> LiftToIntegerStatic for ConstMontyField<Mod, LIMBS> {
+impl<Mod: Params<LIMBS>, const LIMBS: usize>
+    LiftElementStatic<<Self as WithAssociatedInteger>::Integer> for ConstMontyField<Mod, LIMBS>
+{
     #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
+    fn lift(&self) -> <Self as WithAssociatedInteger>::Integer {
         Uint::new(self.0.retrieve())
     }
 }
@@ -806,7 +808,7 @@ mod tests {
 
         // Lifting to integer and projecting back yields the original element.
         for x in [F::zero(), F::one(), F::from(2_u64), F::from(123456789_u64)] {
-            assert_eq!(F::from(x.lift_to_integer()), x);
+            assert_eq!(F::from(x.lift()), x);
         }
     }
 

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    IntSemiring, Semiring, Wrapper, boolean::Boolean, crypto_bigint_int::Int,
+    IntSemiring, LiftElement, Wrapper, boolean::Boolean, crypto_bigint_int::Int,
     crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
 use core::{
@@ -34,6 +34,13 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
     #[allow(clippy::cast_possible_truncation)] // Guaranteed to fit due to crypto_bigint::Uint
     pub const BITS: u32 = LIMBS as u32 * Limb::BITS;
     pub const LIMBS: usize = Mod::LIMBS;
+    /// The largest residue, `modulus - 1`.
+    pub const MAX: Self = Self(ConstMontyForm::new(
+        &Mod::PARAMS
+            .modulus()
+            .as_ref()
+            .wrapping_sub(&crypto_bigint::Uint::ONE),
+    ));
 
     #[inline(always)]
     pub const fn new(value: Uint<LIMBS>) -> Self {
@@ -575,16 +582,16 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Wrapper for ConstMontyField<Mod, LI
 // Semiring, Ring and Field
 //
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> Semiring for ConstMontyField<Mod, LIMBS> {}
+impl<Mod: Params<LIMBS>, const LIMBS: usize> Bounded for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
+    fn min_value() -> Self {
+        Self::ZERO
+    }
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstSemiring for ConstMontyField<Mod, LIMBS> {
-    const MAX: Self = Self(ConstMontyForm::new(
-        &Mod::PARAMS
-            .modulus()
-            .as_ref()
-            .wrapping_sub(&crypto_bigint::Uint::ONE),
-    ));
-    const MIN: Self = Self::ZERO;
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::MAX
+    }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> IntSemiring for ConstMontyField<Mod, LIMBS> {
@@ -600,10 +607,6 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> IntSemiring for ConstMontyField<Mod
         self.lift().is_even()
     }
 }
-
-impl<Mod: Params<LIMBS>, const LIMBS: usize> Ring for ConstMontyField<Mod, LIMBS> {}
-
-impl<Mod: Params<LIMBS>, const LIMBS: usize> FixedField for ConstMontyField<Mod, LIMBS> {}
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstBaseField for ConstMontyField<Mod, LIMBS> {
     const MODULUS: Self::Integer = *Uint::new_ref(Mod::PARAMS.modulus().as_ref());
@@ -621,8 +624,8 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> WithAssociatedInteger for ConstMont
     type Integer = Uint<LIMBS>;
 }
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize>
-    LiftElementStatic<<Self as WithAssociatedInteger>::Integer> for ConstMontyField<Mod, LIMBS>
+impl<Mod: Params<LIMBS>, const LIMBS: usize> LiftElement<<Self as WithAssociatedInteger>::Integer>
+    for ConstMontyField<Mod, LIMBS>
 {
     #[inline(always)]
     fn lift(&self) -> <Self as WithAssociatedInteger>::Integer {
@@ -778,7 +781,7 @@ pub type F32768<Mod> = ConstMontyField<Mod, { 512 * WORD_FACTOR }>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ConstIntRing, FixedBaseField, ensure_type_implements_trait};
+    use crate::{ConstField, ensure_type_implements_trait};
     use crypto_bigint::{Square, U64, U256, const_monty_params};
     use num_traits::{One, Zero};
 
@@ -793,7 +796,7 @@ mod tests {
     #[test]
     fn ensure_traits() {
         ensure_type_implements_trait!(F, Wrapper);
-        ensure_type_implements_trait!(F, ConstIntRing);
+        ensure_type_implements_trait!(F, ConstField);
         ensure_type_implements_trait!(F, ConstBaseField);
     }
 
@@ -805,7 +808,7 @@ mod tests {
         ));
         assert_eq!(F::new(x), F::one());
 
-        assert_eq!(F::from(<F as FixedBaseField>::modulus()), F::zero());
+        assert_eq!(F::from(<F as BaseField>::modulus()), F::zero());
 
         // Lifting to integer and projecting back yields the original element.
         for x in [F::zero(), F::one(), F::from(2_u64), F::from(123456789_u64)] {
@@ -910,7 +913,6 @@ mod tests {
 
     #[test]
     fn min_max() {
-        assert_eq!(F::MIN, F::zero());
         assert_eq!(
             F::MAX,
             F::from_str("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e")
@@ -918,7 +920,7 @@ mod tests {
         );
 
         assert_eq!(F::MAX + F::one(), F::zero());
-        assert_eq!(F::MIN - F::one(), F::MAX);
+        assert_eq!(F::ZERO - F::one(), F::MAX);
         assert_eq!(F::MAX * F::MAX, F::one());
     }
 

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -255,6 +255,23 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Pow<u32> for ConstMontyField<Mod, L
     }
 }
 
+impl<Mod: Params<LIMBS>, const LIMBS: usize> Pow<Uint<LIMBS>> for ConstMontyField<Mod, LIMBS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, rhs: Uint<LIMBS>) -> Self::Output {
+        self.pow(&rhs)
+    }
+}
+
+impl<Mod: Params<LIMBS>, const LIMBS: usize> Pow<&Uint<LIMBS>> for ConstMontyField<Mod, LIMBS> {
+    type Output = Self;
+
+    fn pow(self, rhs: &Uint<LIMBS>) -> Self::Output {
+        Self(self.0.pow(rhs.inner()))
+    }
+}
+
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Inv for ConstMontyField<Mod, LIMBS> {
     type Output = Option<Self>;
 
@@ -1249,14 +1266,20 @@ mod tests {
         let base: F = 2_u64.into();
 
         // Test basic exponentiation
-        assert_eq!(base.pow(0), F::one());
-        assert_eq!(base.pow(1), base);
-        assert_eq!(base.pow(3), F::from(8_u64));
-        assert_eq!(base.pow(10), F::from(1024_u64));
+        assert_eq!(base.pow(0_u32), F::one());
+        assert_eq!(base.pow(1_u32), base);
+        assert_eq!(base.pow(3_u32), F::from(8_u64));
+        assert_eq!(base.pow(10_u32), F::from(1024_u64));
 
         // Test with different base
         let base3: F = 3_u64.into();
-        assert_eq!(base3.pow(4), F::from(81_u64));
+        assert_eq!(base3.pow(4_u32), F::from(81_u64));
+
+        // Same checks via `Uint` (`Self::Integer`) exponents
+        assert_eq!(base.pow(Uint::from(0_u64)), F::one());
+        assert_eq!(base.pow(&Uint::from(3_u64)), F::from(8_u64));
+        assert_eq!(base.pow(Uint::from(10_u64)), F::from(1024_u64));
+        assert_eq!(base3.pow(&Uint::from(4_u64)), F::from(81_u64));
     }
 
     #[test]

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -798,6 +798,7 @@ mod tests {
         ensure_type_implements_trait!(F, Wrapper);
         ensure_type_implements_trait!(F, ConstField);
         ensure_type_implements_trait!(F, ConstBaseField);
+        ensure_type_implements_trait!(FixedConfig<F>, ProjectPrimitiveIntegersWithConfig);
     }
 
     #[test]

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -121,6 +121,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Default for ConstMontyField<Mod, LI
     }
 }
 
+/// Compares Montgomery form, not values.
 impl<Mod: Params<LIMBS>, const LIMBS: usize> PartialOrd for ConstMontyField<Mod, LIMBS> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -128,6 +129,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> PartialOrd for ConstMontyField<Mod,
     }
 }
 
+/// Compares Montgomery form, not values.
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Ord for ConstMontyField<Mod, LIMBS> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -115,18 +115,21 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> Default for ConstMontyField<Mod, LI
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> PartialOrd for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Ord for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         Ord::cmp(self.0.as_montgomery(), other.0.as_montgomery())
     }
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Hash for ConstMontyField<Mod, LIMBS> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.as_montgomery().hash(state)
     }

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    IntRing, IntSemiring, Semiring, Wrapper, boolean::Boolean, crypto_bigint_int::Int,
+    IntSemiring, Semiring, Wrapper, boolean::Boolean, crypto_bigint_int::Int,
     crypto_bigint_uint::Uint,
 };
 use core::{

--- a/src/field/crypto_bigint_helpers.rs
+++ b/src/field/crypto_bigint_helpers.rs
@@ -36,7 +36,7 @@ pub const fn monty_retrieve_inner(
 /// cache-friendly than the FIOS method used in crypto-bigint.
 /// Based on the implementation described in the Section 5 of the paper
 /// "Analyzing and comparing Montgomery multiplication algorithms" with some
-/// slight tweaks: https://www.microsoft.com/en-us/research/wp-content/uploads/1996/01/j37acmon.pdf
+/// slight tweaks: <https://www.microsoft.com/en-us/research/wp-content/uploads/1996/01/j37acmon.pdf>
 pub mod mul {
     use crypto_bigint::{Limb, Uint, WideWord, Word};
     use num_traits::ConstZero;

--- a/src/field/crypto_bigint_helpers.rs
+++ b/src/field/crypto_bigint_helpers.rs
@@ -317,33 +317,40 @@ pub mod pow {
         U: AsRef<UintRef> + AsMut<UintRef> + Clone,
     {
         let exponent = [Limb(Word::from(exponent)); 1];
-        // Only the size matters: `almost_montgomery_mul` zeroes its output
-        // buffer on every use.
-        let mut mul_product = modulus.clone();
-        let mut square_product = modulus.clone();
-
-        pow_montgomery_form_amm(
-            x,
-            &exponent,
-            u32::BITS,
-            one,
-            modulus,
-            |a, b| mul_amm_assign(a, b, &mut mul_product, modulus, mod_neg_inv),
-            |a| square_amm_assign(a, &mut square_product, modulus, mod_neg_inv),
-        )
+        pow_bounded_exp(x, &exponent, u32::BITS, one, modulus, mod_neg_inv)
     }
 
     /// Raise `x` (in Montgomery form) to an exponent, returning a fully
     /// reduced result in Montgomery form.
-    ///
-    /// Wraps [`pow_montgomery_form_amm`] with the AMM closures and the scratch
-    /// buffers they need (mirroring `BoxedMontyMultiplier`'s reusable product
-    /// buffer; one per closure so the mutable borrows stay disjoint).
     pub fn pow<U>(x: &U, exponent: &[Limb], one: U, modulus: &U, mod_neg_inv: Limb) -> U
     where
         U: AsRef<UintRef> + AsMut<UintRef> + Clone,
     {
-        todo!();
+        #[allow(clippy::cast_possible_truncation)] // Limb count fits in u32
+        let exponent_bits = exponent.len() as u32 * Limb::BITS;
+        pow_bounded_exp(x, exponent, exponent_bits, one, modulus, mod_neg_inv)
+    }
+
+    /// Raise `x` (in Montgomery form) to the `exponent_bits` least significant
+    /// bits of `exponent`, returning a fully reduced result in Montgomery
+    /// form.
+    ///
+    /// Wraps [`pow_montgomery_form_amm`] with the AMM closures and the scratch
+    /// buffers they need (mirroring `BoxedMontyMultiplier`'s reusable product
+    /// buffer; one per closure so the mutable borrows stay disjoint).
+    ///
+    /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    pub fn pow_bounded_exp<U>(
+        x: &U,
+        exponent: &[Limb],
+        exponent_bits: u32,
+        one: U,
+        modulus: &U,
+        mod_neg_inv: Limb,
+    ) -> U
+    where
+        U: AsRef<UintRef> + AsMut<UintRef> + Clone,
+    {
         // Only the size matters: `almost_montgomery_mul` zeroes its output
         // buffer on every use.
         let mut mul_product = modulus.clone();
@@ -351,8 +358,8 @@ pub mod pow {
 
         pow_montgomery_form_amm(
             x,
-            &exponent,
-            u32::BITS,
+            exponent,
+            exponent_bits,
             one,
             modulus,
             |a, b| mul_amm_assign(a, b, &mut mul_product, modulus, mod_neg_inv),

--- a/src/field/crypto_bigint_helpers.rs
+++ b/src/field/crypto_bigint_helpers.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects, clippy::needless_range_loop)]
+
 use crypto_bigint::Limb;
 
 /// Copy-paste from `crypto-bigint`
@@ -228,7 +230,7 @@ pub mod pow {
     /// `exponent_bits` represents the length of the exponent in bits.
     ///
     /// NOTE: `exponent_bits` is leaked in the time pattern.
-    pub fn pow_montgomery_form_amm<'a, U>(
+    pub fn pow_montgomery_form_amm<U>(
         x: &U,
         exponent: &[Limb],
         exponent_bits: u32,
@@ -308,27 +310,12 @@ pub mod pow {
 
     /// Raise `x` (in Montgomery form) to a `u32` exponent, returning a fully
     /// reduced result in Montgomery form.
-    ///
-    /// Wraps [`pow_montgomery_form_amm`] with the AMM closures and the scratch
-    /// buffers they need (mirroring `BoxedMontyMultiplier`'s reusable product
-    /// buffer; one per closure so the mutable borrows stay disjoint).
     pub fn pow_u32<U>(x: &U, exponent: u32, one: U, modulus: &U, mod_neg_inv: Limb) -> U
     where
         U: AsRef<UintRef> + AsMut<UintRef> + Clone,
     {
         let exponent = [Limb(Word::from(exponent)); 1];
         pow_bounded_exp(x, &exponent, u32::BITS, one, modulus, mod_neg_inv)
-    }
-
-    /// Raise `x` (in Montgomery form) to an exponent, returning a fully
-    /// reduced result in Montgomery form.
-    pub fn pow<U>(x: &U, exponent: &[Limb], one: U, modulus: &U, mod_neg_inv: Limb) -> U
-    where
-        U: AsRef<UintRef> + AsMut<UintRef> + Clone,
-    {
-        #[allow(clippy::cast_possible_truncation)] // Limb count fits in u32
-        let exponent_bits = exponent.len() as u32 * Limb::BITS;
-        pow_bounded_exp(x, exponent, exponent_bits, one, modulus, mod_neg_inv)
     }
 
     /// Raise `x` (in Montgomery form) to the `exponent_bits` least significant

--- a/src/field/crypto_bigint_helpers.rs
+++ b/src/field/crypto_bigint_helpers.rs
@@ -1,3 +1,33 @@
+use crypto_bigint::Limb;
+
+/// Copy-paste from `crypto-bigint`
+#[inline(always)]
+pub const fn monty_retrieve_inner(
+    x: &[Limb],
+    out: &mut [Limb],
+    modulus: &[Limb],
+    mod_neg_inv: Limb,
+) {
+    let nlimbs = modulus.len();
+    assert!(nlimbs == x.len() && nlimbs == out.len());
+
+    let mut i = 0;
+    while i < nlimbs {
+        let xi = x[i];
+        let u = out[0].wrapping_add(xi).wrapping_mul(mod_neg_inv);
+
+        out[0] = u.carrying_mul_add(modulus[0], xi, out[0]).1;
+
+        let mut j = 1;
+        while j < nlimbs {
+            (out[j - 1], out[j]) = u.carrying_mul_add(modulus[j], out[j], out[j - 1]);
+            j += 1;
+        }
+
+        i += 1;
+    }
+}
+
 /// Optimized Montgomery multiplication.
 ///
 /// Uses CIOS (Coarsely Integrated Operand Scanning) method which is more
@@ -6,7 +36,7 @@
 /// "Analyzing and comparing Montgomery multiplication algorithms" with some
 /// slight tweaks: https://www.microsoft.com/en-us/research/wp-content/uploads/1996/01/j37acmon.pdf
 pub mod mul {
-    use crypto_bigint::{Uint, WideWord, Word};
+    use crypto_bigint::{Limb, Uint, WideWord, Word};
     use num_traits::ConstZero;
 
     const LOG2_WORD_BITS: u32 = Word::BITS.trailing_zeros();
@@ -44,8 +74,7 @@ pub mod mul {
         let mod_neg_inv = compute_mod_neg_inv(mod_words[0]);
 
         let mut result = [0; LIMBS];
-        let carry =
-            montgomery_mul_cios::<LIMBS>(a_words, b_words, mod_words, mod_neg_inv, &mut result);
+        let carry = monty_mul_cios::<LIMBS>(a_words, b_words, mod_words, mod_neg_inv, &mut result);
 
         // Conditional subtraction: subtract modulus if carry != 0 OR result >= modulus
         // First compute result - modulus
@@ -78,7 +107,7 @@ pub mod mul {
     /// Expects `out` to be initialized to zero.
     #[inline(always)]
     #[allow(clippy::arithmetic_side_effects)]
-    fn montgomery_mul_cios<const LIMBS: usize>(
+    pub fn monty_mul_cios<const LIMBS: usize>(
         a: &[Word; LIMBS],
         b: &[Word; LIMBS],
         modulus: &[Word; LIMBS],
@@ -127,5 +156,301 @@ pub mod mul {
     fn mul_add_carry(a: Word, b: Word, c: Word, d: Word) -> (Word, Word) {
         let wide = WideWord::from(a) * WideWord::from(b) + WideWord::from(c) + WideWord::from(d);
         (wide as Word, (wide >> Word::BITS) as Word)
+    }
+
+    /// Copy-paste from `crypto-bigint`
+    #[inline(always)]
+    #[allow(clippy::cast_possible_truncation)]
+    pub const fn monty_mul_limbs(
+        x: &[Limb],
+        y: &[Limb],
+        out: &mut [Limb],
+        modulus: &[Limb],
+        mod_neg_inv: Limb,
+    ) -> Limb {
+        let nlimbs = modulus.len();
+        assert!(nlimbs == x.len() && nlimbs == y.len() && nlimbs == out.len());
+
+        let mut meta_carry = 0;
+
+        let mut i = 0;
+        while i < nlimbs {
+            let xi = x[i];
+            // A[0] + x[i]y[0] <= (2^64 - 1)^2 + (2^64 - 1) = 2^128 - 2^64
+            let axy = (xi.0 as WideWord) * (y[0].0 as WideWord) + out[0].0 as WideWord;
+            let u = (axy as Word).wrapping_mul(mod_neg_inv.0);
+
+            let mut carry;
+            // A[0] + x[i]y[0] + um[0] <= (2^128 - 1) + (2^128 - 2^64) = 2^129 - 2^64 - 1
+            let (a, c) = ((u as WideWord) * (modulus[0].0 as WideWord)).overflowing_add(axy);
+            // carry <= (2^129 - 2^64 - 1) / 2^64 <= 2^65 - 2
+            carry = ((c as WideWord) << Word::BITS) | (a >> Word::BITS);
+
+            let mut j = 1;
+            while j < nlimbs {
+                // A[j] + x[i]y[j] <= (2^64 - 1)^2 + (2^64 - 1) = 2^128 - 2^64
+                let axy = (xi.0 as WideWord) * (y[j].0 as WideWord) + out[j].0 as WideWord;
+                // um[j] + carry <= (2^64 - 1)^2 + (2^65 - 2) = 2^128 - 1
+                let umc = (u as WideWord) * (modulus[j].0 as WideWord) + carry;
+                let (ab, c) = axy.overflowing_add(umc);
+                out[j - 1] = Limb(ab as Word);
+                // carry <= (2^129 - 2^64 - 1) / 2^64 <= 2^65 - 2
+                carry = ((c as WideWord) << Word::BITS) | (ab >> Word::BITS);
+                j += 1;
+            }
+
+            carry += meta_carry;
+            (out[nlimbs - 1], meta_carry) = (Limb(carry as Word), carry >> Word::BITS);
+
+            i += 1;
+        }
+
+        Limb(meta_carry as Word)
+    }
+}
+
+pub mod pow {
+    use crate::IntSemiring;
+    use core::{array, mem};
+    use crypto_bigint::{Limb, UintRef, Word};
+
+    const WINDOW: u32 = 4;
+    const WINDOW_COUNT: usize = 1 << WINDOW;
+    const WINDOW_MASK: Word = (1 << WINDOW) - 1;
+    const BITS_PER_WINDOW: u32 = Limb::BITS / WINDOW;
+
+    /// Performs modular exponentiation using "Almost Montgomery
+    /// Multiplication".
+    ///
+    /// Returns a result which has been fully reduced by the modulus specified
+    /// in `params`.
+    ///
+    /// `exponent_bits` represents the length of the exponent in bits.
+    ///
+    /// NOTE: `exponent_bits` is leaked in the time pattern.
+    pub fn pow_montgomery_form_amm<'a, U>(
+        x: &U,
+        exponent: &[Limb],
+        exponent_bits: u32,
+        one: U,
+        modulus: &U,
+        mut mul_amm_assign: impl FnMut(&mut U, &U),
+        mut square_amm_assign: impl FnMut(&mut U),
+    ) -> U
+    where
+        U: AsRef<UintRef> + AsMut<UintRef> + Clone,
+    {
+        if exponent_bits == 0 {
+            return one; // 1 in Montgomery form
+        }
+
+        let mut power = x.clone();
+
+        // powers[i] contains x^i
+        let powers: [U; WINDOW_COUNT] = array::from_fn(|n| {
+            if n == 0 {
+                one.clone()
+            } else if n == WINDOW_COUNT - 1 {
+                power.clone()
+            } else {
+                let mut new_power = power.clone();
+                mul_amm_assign(&mut new_power, x);
+
+                mem::swap(&mut power, &mut new_power);
+                new_power
+            }
+        });
+
+        let (starting_limb, starting_window, starting_window_mask) = pow_init(exponent_bits);
+
+        let mut z = one; // 1 in Montgomery form
+        let mut power = powers[0].clone();
+
+        for limb_num in (0..=starting_limb).rev() {
+            let w = exponent[limb_num].0;
+
+            let mut window_num = if limb_num == starting_limb {
+                starting_window + 1
+            } else {
+                BITS_PER_WINDOW
+            };
+
+            while window_num > 0 {
+                window_num -= 1;
+
+                let mut idx = (w >> (window_num * WINDOW)) & WINDOW_MASK;
+
+                if limb_num == starting_limb && window_num == starting_window {
+                    idx &= starting_window_mask;
+                } else {
+                    for _ in 1..=WINDOW {
+                        square_amm_assign(&mut z);
+                    }
+                }
+
+                power
+                    .as_mut()
+                    .as_mut_limbs()
+                    .copy_from_slice(powers[0].as_ref().as_limbs());
+                for i in 1..WINDOW_COUNT {
+                    if (i as Word) == idx {
+                        power = powers[i].clone();
+                    }
+                }
+
+                mul_amm_assign(&mut z, &power);
+            }
+        }
+
+        almost_montgomery_reduce(z.as_mut(), modulus.as_ref());
+        z
+    }
+
+    /// Raise `x` (in Montgomery form) to a `u32` exponent, returning a fully
+    /// reduced result in Montgomery form.
+    ///
+    /// Wraps [`pow_montgomery_form_amm`] with the AMM closures and the scratch
+    /// buffers they need (mirroring `BoxedMontyMultiplier`'s reusable product
+    /// buffer; one per closure so the mutable borrows stay disjoint).
+    pub fn pow_u32<U>(x: &U, exponent: u32, one: U, modulus: &U, mod_neg_inv: Limb) -> U
+    where
+        U: AsRef<UintRef> + AsMut<UintRef> + Clone,
+    {
+        let exponent = [Limb(Word::from(exponent)); 1];
+        // Only the size matters: `almost_montgomery_mul` zeroes its output
+        // buffer on every use.
+        let mut mul_product = modulus.clone();
+        let mut square_product = modulus.clone();
+
+        pow_montgomery_form_amm(
+            x,
+            &exponent,
+            u32::BITS,
+            one,
+            modulus,
+            |a, b| mul_amm_assign(a, b, &mut mul_product, modulus, mod_neg_inv),
+            |a| square_amm_assign(a, &mut square_product, modulus, mod_neg_inv),
+        )
+    }
+
+    /// Raise `x` (in Montgomery form) to an exponent, returning a fully
+    /// reduced result in Montgomery form.
+    ///
+    /// Wraps [`pow_montgomery_form_amm`] with the AMM closures and the scratch
+    /// buffers they need (mirroring `BoxedMontyMultiplier`'s reusable product
+    /// buffer; one per closure so the mutable borrows stay disjoint).
+    pub fn pow<U>(x: &U, exponent: &[Limb], one: U, modulus: &U, mod_neg_inv: Limb) -> U
+    where
+        U: AsRef<UintRef> + AsMut<UintRef> + Clone,
+    {
+        todo!();
+        // Only the size matters: `almost_montgomery_mul` zeroes its output
+        // buffer on every use.
+        let mut mul_product = modulus.clone();
+        let mut square_product = modulus.clone();
+
+        pow_montgomery_form_amm(
+            x,
+            &exponent,
+            u32::BITS,
+            one,
+            modulus,
+            |a, b| mul_amm_assign(a, b, &mut mul_product, modulus, mod_neg_inv),
+            |a| square_amm_assign(a, &mut square_product, modulus, mod_neg_inv),
+        )
+    }
+
+    /// Mirrors `BoxedMontyMultiplier::mul_amm_assign` from `crypto-bigint`:
+    /// perform an "Almost Montgomery Multiplication", assigning the product to
+    /// `a`.
+    ///
+    /// `product` is a reusable scratch buffer of the same precision as
+    /// `modulus`.
+    ///
+    /// NOTE: the result is reduced to the *bit length* of the modulus, but may
+    /// still exceed the modulus; a final [`almost_montgomery_reduce`] is
+    /// required for a fully reduced result.
+    fn mul_amm_assign<U: AsRef<UintRef> + AsMut<UintRef>>(
+        a: &mut U,
+        b: &U,
+        product: &mut U,
+        modulus: &U,
+        mod_neg_inv: Limb,
+    ) {
+        almost_montgomery_mul(
+            a.as_ref().as_limbs(),
+            b.as_ref().as_limbs(),
+            product.as_mut(),
+            modulus.as_ref(),
+            mod_neg_inv,
+        );
+        a.as_mut()
+            .as_mut_limbs()
+            .copy_from_slice(product.as_ref().as_limbs());
+    }
+
+    /// Mirrors `BoxedMontyMultiplier::square_amm_assign` from `crypto-bigint`;
+    /// see [`mul_amm_assign`].
+    fn square_amm_assign<U: AsRef<UintRef> + AsMut<UintRef>>(
+        a: &mut U,
+        product: &mut U,
+        modulus: &U,
+        mod_neg_inv: Limb,
+    ) {
+        let a_limbs = a.as_ref().as_limbs();
+        almost_montgomery_mul(
+            a_limbs,
+            a_limbs,
+            product.as_mut(),
+            modulus.as_ref(),
+            mod_neg_inv,
+        );
+        a.as_mut()
+            .as_mut_limbs()
+            .copy_from_slice(product.as_ref().as_limbs());
+    }
+
+    /// Mirrors `almost_montgomery_mul` from `crypto-bigint`, delegating the
+    /// inner multiplication to [`super::mul::monty_mul_limbs`].
+    fn almost_montgomery_mul(
+        x: &[Limb],
+        y: &[Limb],
+        out: &mut UintRef,
+        modulus: &UintRef,
+        mod_neg_inv: Limb,
+    ) {
+        out.as_mut_limbs().fill(Limb::ZERO);
+        let overflow =
+            super::mul::monty_mul_limbs(x, y, out.as_mut_limbs(), modulus.as_limbs(), mod_neg_inv);
+        conditional_borrowing_sub_assign(out, modulus, overflow.0.is_odd());
+    }
+
+    fn pow_init(exponent_bits: u32) -> (usize, u32, Word) {
+        let starting_limb = ((exponent_bits - 1) / Limb::BITS) as usize;
+        let starting_bit_in_limb = (exponent_bits - 1) % Limb::BITS;
+        let starting_window = starting_bit_in_limb / WINDOW;
+        let starting_window_mask = (1 << (starting_bit_in_limb % WINDOW + 1)) - 1;
+        (starting_limb, starting_window, starting_window_mask)
+    }
+
+    fn almost_montgomery_reduce(z: &mut UintRef, modulus: &UintRef) {
+        let choice = UintRef::cmp_vartime(z, modulus).is_ge();
+        conditional_borrowing_sub_assign(z, modulus, choice);
+        conditional_borrowing_sub_assign(z, modulus, choice);
+    }
+
+    fn conditional_borrowing_sub_assign(lhs: &mut UintRef, rhs: &UintRef, choice: bool) -> bool {
+        debug_assert!(lhs.bits_precision() <= rhs.bits_precision());
+        let mask = if choice { Limb::MAX } else { Limb::ZERO };
+        let mut borrow = Limb::ZERO;
+
+        for i in 0..lhs.nlimbs() {
+            let masked_rhs = *rhs.as_limbs().get(i).unwrap_or(&Limb::ZERO) & mask;
+            let (limb, b) = lhs.as_limbs()[i].borrowing_sub(masked_rhs, borrow);
+            lhs.as_mut_limbs()[i] = limb;
+            borrow = b;
+        }
+
+        borrow.0.is_odd()
     }
 }

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -1,13 +1,14 @@
 use super::*;
 use crate::{
-    IntRing, Wrapper, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
-    helpers::crypto_bigint as helpers,
+    IntSemiring, IntSemiringConfig, LiftElementWithConfig, Wrapper, boolean::Boolean,
+    crypto_bigint_int::Int, crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
     BitOps, Limb, NonZero, Odd, Word,
     modular::{FixedMontyForm, FixedMontyParams},
 };
+use num_traits::Signed;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MontyField<const LIMBS: usize> {
@@ -109,9 +110,11 @@ impl<const LIMBS: usize> Display for MontyField<LIMBS> {
 // Field operations
 //
 
-impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
+impl<const LIMBS: usize> SetConfig for MontyField<LIMBS> {
     type Element = MontyFieldElement<LIMBS>;
+}
 
+impl<const LIMBS: usize> SemiringConfig for MontyField<LIMBS> {
     fn is_zero(&self, value: &Self::Element) -> bool {
         value.0.inner().is_zero_vartime()
     }
@@ -122,12 +125,6 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
 
     fn one(&self) -> Self::Element {
         (*self.params.one()).into()
-    }
-
-    fn neg(&self, x: &Self::Element) -> Self::Element {
-        x.0.inner()
-            .neg_mod(self.params.modulus().as_nz_ref())
-            .into()
     }
 
     fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
@@ -142,6 +139,70 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
             .into()
     }
 
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        helpers::mul::monty_mul(x.0.inner(), y.0.inner(), self.params.modulus().as_ref()).into()
+    }
+
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
+        helpers::pow::pow_u32(
+            x.0.inner(),
+            y,
+            *self.params.one(),
+            self.params.modulus().as_ref(),
+            self.params.mod_neg_inv(),
+        )
+        .into()
+    }
+
+    // Modular arithmetic cannot overflow, so the checked variants always
+    // succeed.
+
+    fn checked_add(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.add(x, y))
+    }
+
+    fn checked_sub(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.sub(x, y))
+    }
+
+    fn checked_mul(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        Some(self.mul(x, y))
+    }
+
+    fn checked_pow_u32(&self, x: &Self::Element, y: u32) -> Option<Self::Element> {
+        Some(self.pow_u32(x, y))
+    }
+
+    // Assign operations use the default implementations, which delegate to the
+    // operations above (`Uint` arithmetic is not in-place anyway)
+}
+
+impl<const LIMBS: usize> RingConfig for MontyField<LIMBS> {
+    fn neg(&self, x: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .neg_mod(self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn checked_neg(&self, x: &Self::Element) -> Option<Self::Element> {
+        Some(self.neg(x))
+    }
+}
+
+impl<const LIMBS: usize> IntSemiringConfig for MontyField<LIMBS> {
+    // Parity is a property of the represented residue, so it requires leaving
+    // the Montgomery domain.
+
+    fn is_odd(&self, x: &Self::Element) -> bool {
+        IntSemiring::is_odd(&self.lift(x))
+    }
+
+    fn is_even(&self, x: &Self::Element) -> bool {
+        IntSemiring::is_even(&self.lift(x))
+    }
+}
+
+impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
     fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
         // Follows FixedMontyForm::invert_vartime, but avoids the params copies
         // of assembling forms: invert the Montgomery representation directly,
@@ -158,10 +219,6 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
         Some(helpers::mul::monty_mul(&x_inv, r2, modulus.as_ref()).into())
     }
 
-    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
-        helpers::mul::monty_mul(x.0.inner(), y.0.inner(), self.params.modulus().as_ref()).into()
-    }
-
     fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
         helpers::pow::pow_bounded_exp(
             x.0.inner(),
@@ -173,20 +230,13 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
         )
         .into()
     }
+}
 
-    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
-        helpers::pow::pow_u32(
-            x.0.inner(),
-            y,
-            *self.params.one(),
-            self.params.modulus().as_ref(),
-            self.params.mod_neg_inv(),
-        )
-        .into()
+impl<const LIMBS: usize> WithExtensionDegree for MontyField<LIMBS> {
+    #[inline(always)]
+    fn extension_degree() -> u64 {
+        1
     }
-
-    // Assign operations use the default implementations, which delegate to the
-    // operations above (`Uint` arithmetic is not in-place anyway)
 }
 
 //
@@ -196,7 +246,7 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
 macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
-            impl<const LIMBS: usize> ProjectElementDynamic<$t> for MontyField<LIMBS> {
+            impl<const LIMBS: usize> ProjectElementWithConfig<$t> for MontyField<LIMBS> {
                 fn project(&self, value: &$t) -> Self::Element {
                     let abs: crypto_bigint::Uint<LIMBS> = (*value).into();
                     self.project(&Uint::new(abs))
@@ -209,7 +259,7 @@ macro_rules! impl_from_unsigned {
 macro_rules! impl_from_signed {
     ($($t:ty),* $(,)?) => {
         $(
-            impl<const LIMBS: usize> ProjectElementDynamic<$t> for MontyField<LIMBS> {
+            impl<const LIMBS: usize> ProjectElementWithConfig<$t> for MontyField<LIMBS> {
                 fn project(&self, value: &$t) -> Self::Element {
                     let magnitude: crypto_bigint::Uint<LIMBS> = value.abs_diff(0).into();
                     let magnitude = self.project(&Uint::new(magnitude));
@@ -223,20 +273,20 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
-impl<const LIMBS: usize> ProjectElementDynamic<bool> for MontyField<LIMBS> {
+impl<const LIMBS: usize> ProjectElementWithConfig<bool> for MontyField<LIMBS> {
     fn project(&self, value: &bool) -> Self::Element {
         if *value { self.one() } else { self.zero() }
     }
 }
 
-impl<const LIMBS: usize> ProjectElementDynamic<Boolean> for MontyField<LIMBS> {
+impl<const LIMBS: usize> ProjectElementWithConfig<Boolean> for MontyField<LIMBS> {
     #[inline(always)]
     fn project(&self, value: &Boolean) -> Self::Element {
         self.project(value.inner())
     }
 }
 
-impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementDynamic<Int<LIMBS2>>
+impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementWithConfig<Int<LIMBS2>>
     for MontyField<LIMBS>
 {
     fn project(&self, value: &Int<LIMBS2>) -> Self::Element {
@@ -249,7 +299,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementDynamic<Int<LIMBS2>>
     }
 }
 
-impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementDynamic<Uint<LIMBS2>>
+impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementWithConfig<Uint<LIMBS2>>
     for MontyField<LIMBS>
 {
     /// Convert the given integer into the Montgomery domain.
@@ -299,13 +349,13 @@ impl<const LIMBS: usize> WithAssociatedInteger for MontyField<LIMBS> {
     type Integer = Uint<LIMBS>;
 }
 
-impl<const LIMBS: usize> LiftElementDynamic<<Self as WithAssociatedInteger>::Integer>
+impl<const LIMBS: usize> LiftElementWithConfig<<Self as WithAssociatedInteger>::Integer>
     for MontyField<LIMBS>
 {
     /// Retrieves the integer currently encoded in this [`MontyField`],
     /// guaranteed to be reduced.
     #[inline(always)]
-    fn lift(&self, value: &Self::Element) -> Self::Integer {
+    fn lift(&self, value: &Self::Element) -> <Self as WithAssociatedInteger>::Integer {
         let mut out = crypto_bigint::Uint::<LIMBS>::ZERO;
         helpers::monty_retrieve_inner(
             value.0.inner().as_limbs(),

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{IntRing, Wrapper, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
-    NonZero, Odd, One,
+    BitOps, NonZero, Odd, One,
     modular::{FixedMontyForm, FixedMontyParams},
 };
 
@@ -160,9 +160,10 @@ impl<const LIMBS: usize> FieldConfigOps for MontyField<LIMBS> {
     }
 
     fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
-        crypto_bigint_helpers::pow::pow(
+        crypto_bigint_helpers::pow::pow_bounded_exp(
             x.0.inner(),
             y.inner().as_limbs(),
+            y.inner().bits_precision(),
             *self.params.one(),
             self.params.modulus().as_ref(),
             self.params.mod_neg_inv(),

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -367,6 +367,17 @@ impl<const LIMBS: usize> LiftElementWithConfig<<Self as WithAssociatedInteger>::
     }
 }
 
+//
+// Zeroize
+//
+
+#[cfg(feature = "zeroize")]
+impl<const LIMBS: usize> zeroize::Zeroize for MontyFieldElement<LIMBS> {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
 // TODO: Do we want to zeroize the modulus?
 
 //

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntRing, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use crate::{IntRing, Wrapper, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
     NonZero, Odd, One,
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
     /// Montgomery value.
     #[inline(always)]
     pub const fn form(&self, el: &MontyFieldElement<LIMBS>) -> FixedMontyForm<LIMBS> {
-        FixedMontyForm::from_montgomery(*el.0.inner(), &self.params)
+        FixedMontyForm::from_montgomery(el.0.0, &self.params)
     }
 }
 
@@ -56,6 +56,34 @@ impl<const LIMBS: usize> From<crypto_bigint::Uint<LIMBS>> for MontyFieldElement<
     #[inline(always)]
     fn from(value: crypto_bigint::Uint<LIMBS>) -> Self {
         Self(Uint::new(value))
+    }
+}
+
+//
+// Wrapper
+//
+
+impl<const LIMBS: usize> Wrapper for MontyFieldElement<LIMBS> {
+    type Inner = Uint<LIMBS>;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
     }
 }
 
@@ -200,7 +228,7 @@ impl<const LIMBS: usize> ProjectElement<bool> for MontyField<LIMBS> {
 impl<const LIMBS: usize> ProjectElement<Boolean> for MontyField<LIMBS> {
     #[inline(always)]
     fn project(&self, value: &Boolean) -> Self::Element {
-        self.project(&value.inner())
+        self.project(value.inner())
     }
 }
 

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -368,6 +368,36 @@ impl<const LIMBS: usize> LiftElementWithConfig<<Self as WithAssociatedInteger>::
 }
 
 //
+// Serialization and Deserialization
+//
+
+#[cfg(feature = "serde")]
+impl<'de, const LIMBS: usize> serde::Deserialize<'de> for MontyFieldElement<LIMBS>
+where
+    crypto_bigint::Uint<LIMBS>: crypto_bigint::Encoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Uint::<LIMBS>::deserialize(deserializer).map(Self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<const LIMBS: usize> serde::Serialize for MontyFieldElement<LIMBS>
+where
+    crypto_bigint::Uint<LIMBS>: crypto_bigint::Encoding,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+//
 // Zeroize
 //
 

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -106,7 +106,7 @@ impl<const LIMBS: usize> Display for MontyField<LIMBS> {
 // Field operations
 //
 
-impl<const LIMBS: usize> FieldConfigOps for MontyField<LIMBS> {
+impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
     type Element = MontyFieldElement<LIMBS>;
 
     fn is_zero(&self, value: &Self::Element) -> bool {
@@ -198,7 +198,7 @@ impl<const LIMBS: usize> FieldConfigOps for MontyField<LIMBS> {
 macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
-            impl<const LIMBS: usize> ProjectElement<$t> for MontyField<LIMBS> {
+            impl<const LIMBS: usize> ProjectElementDynamic<$t> for MontyField<LIMBS> {
                 fn project(&self, value: &$t) -> Self::Element {
                     let abs: crypto_bigint::Uint<LIMBS> = (*value).into();
                     self.project(&Uint::new(abs))
@@ -211,7 +211,7 @@ macro_rules! impl_from_unsigned {
 macro_rules! impl_from_signed {
     ($($t:ty),* $(,)?) => {
         $(
-            impl<const LIMBS: usize> ProjectElement<$t> for MontyField<LIMBS> {
+            impl<const LIMBS: usize> ProjectElementDynamic<$t> for MontyField<LIMBS> {
                 fn project(&self, value: &$t) -> Self::Element {
                     let magnitude: crypto_bigint::Uint<LIMBS> = value.abs_diff(0).into();
                     let magnitude = self.project(&Uint::new(magnitude));
@@ -225,20 +225,22 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
-impl<const LIMBS: usize> ProjectElement<bool> for MontyField<LIMBS> {
+impl<const LIMBS: usize> ProjectElementDynamic<bool> for MontyField<LIMBS> {
     fn project(&self, value: &bool) -> Self::Element {
         if *value { self.one() } else { self.zero() }
     }
 }
 
-impl<const LIMBS: usize> ProjectElement<Boolean> for MontyField<LIMBS> {
+impl<const LIMBS: usize> ProjectElementDynamic<Boolean> for MontyField<LIMBS> {
     #[inline(always)]
     fn project(&self, value: &Boolean) -> Self::Element {
         self.project(value.inner())
     }
 }
 
-impl<const LIMBS: usize, const LIMBS2: usize> ProjectElement<Int<LIMBS2>> for MontyField<LIMBS> {
+impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementDynamic<Int<LIMBS2>>
+    for MontyField<LIMBS>
+{
     fn project(&self, value: &Int<LIMBS2>) -> Self::Element {
         let abs = self.project(&Uint::new(value.inner().abs()));
         if value.is_negative() {
@@ -249,7 +251,9 @@ impl<const LIMBS: usize, const LIMBS2: usize> ProjectElement<Int<LIMBS2>> for Mo
     }
 }
 
-impl<const LIMBS: usize, const LIMBS2: usize> ProjectElement<Uint<LIMBS2>> for MontyField<LIMBS> {
+impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementDynamic<Uint<LIMBS2>>
+    for MontyField<LIMBS>
+{
     /// Convert the given integer into the Montgomery domain.
     fn project(&self, value: &Uint<LIMBS2>) -> Self::Element {
         let value: crypto_bigint::Uint<LIMBS> = if LIMBS >= LIMBS2 {
@@ -302,11 +306,13 @@ impl<const LIMBS: usize> WithAssociatedInteger for MontyField<LIMBS> {
     type Integer = Uint<LIMBS>;
 }
 
-impl<const LIMBS: usize> LiftToIntegerDynamic for MontyField<LIMBS> {
+impl<const LIMBS: usize> LiftElementDynamic<<Self as WithAssociatedInteger>::Integer>
+    for MontyField<LIMBS>
+{
     /// Retrieves the integer currently encoded in this [`MontyField`],
     /// guaranteed to be reduced.
     #[inline(always)]
-    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
+    fn lift(&self, value: &Self::Element) -> Self::Integer {
         let mut out = crypto_bigint::Uint::<LIMBS>::ZERO;
         crypto_bigint_helpers::monty_retrieve_inner(
             value.0.inner().as_limbs(),
@@ -407,7 +413,7 @@ mod tests {
             f.project(&2_u64),
             f.project(&123456789_u64),
         ] {
-            assert_eq!(f.project(&f.lift_to_integer(&x)), x);
+            assert_eq!(f.project(&f.lift(&x)), x);
         }
     }
 

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -1,97 +1,61 @@
 use super::*;
-use crate::{
-    IntRing, Semiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
-};
-use core::{
-    cmp::Ordering,
-    fmt::{Debug, Display, Formatter, Result as FmtResult},
-    hash::{Hash, Hasher},
-    iter::{Product, Sum},
-    ops::{Add, AddAssign, DivAssign, Mul, MulAssign, Rem, Sub, SubAssign},
-};
+use crate::{IntRing, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use core::fmt::{Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
     NonZero, Odd, One,
     modular::{FixedMontyForm, FixedMontyParams},
 };
-use crypto_primitives_proc_macros::InfallibleCheckedOp;
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, Pow};
 
-#[derive(Clone, PartialEq, Eq, InfallibleCheckedOp)]
-#[infallible_checked_unary_op((CheckedNeg, neg))]
-#[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct MontyField<const LIMBS: usize>(FixedMontyForm<LIMBS>);
+pub struct MontyField<const LIMBS: usize> {
+    pub params: FixedMontyParams<LIMBS>,
+}
 
 impl<const LIMBS: usize> MontyField<LIMBS> {
     pub const LIMBS: usize = LIMBS;
 
-    /// Creates a new `MontyField` from a `MontyForm`.
+    /// Creates a new [`MontyField`] from [`FixedMontyParams`].
     #[inline(always)]
-    pub const fn new(form: FixedMontyForm<LIMBS>) -> Self {
-        Self(form)
+    pub const fn wrap(params: FixedMontyParams<LIMBS>) -> Self {
+        Self { params }
     }
 
+    /// Unwrap the [`FixedMontyForm`] into a field config and a field element.
+    pub const fn unwrap_monty(el: FixedMontyForm<LIMBS>) -> (Self, Uint<LIMBS>) {
+        (
+            Self {
+                params: *el.params(),
+            },
+            Uint::new(el.to_montgomery()),
+        )
+    }
+
+    /// Reassemble the `crypto-bigint`'s [`FixedMontyForm`] from a raw
+    /// Montgomery value.
     #[inline(always)]
-    pub const fn new_unchecked(inner: Uint<LIMBS>, config: &FixedMontyParams<LIMBS>) -> Self {
-        Self(FixedMontyForm::from_montgomery(inner.into_inner(), config))
+    pub const fn form(&self, el: &MontyFieldElement<LIMBS>) -> FixedMontyForm<LIMBS> {
+        FixedMontyForm::from_montgomery(*el.0.inner(), &self.params)
     }
+}
 
+/// A wrapper around [`Uint`] to prevent accidentally calling math operations
+/// on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct MontyFieldElement<const LIMBS: usize>(pub Uint<LIMBS>);
+
+impl<const LIMBS: usize> From<Uint<LIMBS>> for MontyFieldElement<LIMBS> {
     #[inline(always)]
-    pub const fn inner(&self) -> &Uint<LIMBS> {
-        Uint::new_ref(self.0.as_montgomery())
+    fn from(value: Uint<LIMBS>) -> Self {
+        Self(value)
     }
+}
 
+impl<const LIMBS: usize> From<crypto_bigint::Uint<LIMBS>> for MontyFieldElement<LIMBS> {
     #[inline(always)]
-    pub const fn into_inner(self) -> Uint<LIMBS> {
-        Uint::new(self.0.to_montgomery())
-    }
-
-    /// Retrieves the integer currently encoded in this [`MontyForm`],
-    /// guaranteed to be reduced.
-    pub const fn retrieve(&self) -> Uint<LIMBS> {
-        Uint::new(self.0.retrieve())
-    }
-
-    /// Access the value in Montgomery form.
-    pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
-        Uint::new_ref(self.0.as_montgomery())
-    }
-
-    /// Mutably access the value in Montgomery form.
-    pub fn as_montgomery_mut(&mut self) -> &mut Uint<LIMBS> {
-        Uint::new_ref_mut(self.0.as_montgomery_mut())
-    }
-
-    /// Create a `MontyField` from a value in Montgomery form.
-    pub const fn from_montgomery(integer: Uint<LIMBS>, config: &FixedMontyParams<LIMBS>) -> Self {
-        Self(FixedMontyForm::from_montgomery(
-            integer.into_inner(),
-            config,
-        ))
-    }
-
-    /// Extract the value from the `MontyForm` in Montgomery form.
-    pub const fn to_montgomery(&self) -> Uint<LIMBS> {
-        Uint::new(self.0.to_montgomery())
-    }
-
-    /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    pub const fn div_by_2(&self) -> Self {
-        Self(self.0.div_by_2())
-    }
-
-    /// Double `self`.
-    pub const fn double(&self) -> Self {
-        Self(self.0.double())
-    }
-
-    /// See [MontyForm::pow_bounded_exp].
-    pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
-        &self,
-        exponent: &Uint<RHS_LIMBS>,
-        exponent_bits: u32,
-    ) -> Self {
-        Self(self.0.pow_bounded_exp(exponent.inner(), exponent_bits))
+    fn from(value: crypto_bigint::Uint<LIMBS>) -> Self {
+        Self(Uint::new(value))
     }
 }
 
@@ -99,278 +63,100 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
 // Core traits
 //
 
-impl<const LIMBS: usize> Debug for MontyField<LIMBS> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Debug::fmt(&self.0, f)
-    }
-}
-
 impl<const LIMBS: usize> Display for MontyField<LIMBS> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(
-            f,
-            "{} (mod {})",
-            self.0.retrieve(),
-            self.0.params().modulus()
+        write!(f, "F_{}", self.params.modulus())
+    }
+}
+
+//
+// Field operations
+//
+
+impl<const LIMBS: usize> FieldConfigOps for MontyField<LIMBS> {
+    type Element = MontyFieldElement<LIMBS>;
+
+    fn is_zero(&self, value: &Self::Element) -> bool {
+        value.0.inner().is_zero_vartime()
+    }
+
+    fn zero(&self) -> Self::Element {
+        crypto_bigint::Uint::ZERO.into()
+    }
+
+    fn one(&self) -> Self::Element {
+        (*self.params.one()).into()
+    }
+
+    fn neg(&self, x: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .neg_mod(self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .add_mod(y.0.inner(), self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.0.inner()
+            .sub_mod(y.0.inner(), self.params.modulus().as_nz_ref())
+            .into()
+    }
+
+    fn inv(&self, x: &Self::Element) -> Option<Self::Element> {
+        // Follows FixedMontyForm::invert_vartime, but avoids the params copies
+        // of assembling forms: invert the Montgomery representation directly,
+        // then bring the plain inverse back into the Montgomery domain.
+        // (xR)⁻¹ = x⁻¹R⁻¹, and two Montgomery multiplications by R² yield the
+        // Montgomery form x⁻¹R.
+        let modulus = self.params.modulus();
+        let inverted: Option<crypto_bigint::Uint<LIMBS>> =
+            x.0.inner().invert_odd_mod_vartime(modulus).into();
+        let inverted = inverted?;
+
+        let r2 = self.params.r2();
+        let x_inv = crypto_bigint_helpers::mul::monty_mul(&inverted, r2, modulus.as_ref());
+        Some(crypto_bigint_helpers::mul::monty_mul(&x_inv, r2, modulus.as_ref()).into())
+    }
+
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        crypto_bigint_helpers::mul::monty_mul(
+            x.0.inner(),
+            y.0.inner(),
+            self.params.modulus().as_ref(),
         )
+        .into()
     }
-}
 
-impl<const LIMBS: usize> PartialOrd for MontyField<LIMBS> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.cfg().modulus() != other.cfg().modulus() {
-            return None;
-        }
-        Some(Ord::cmp(self.0.as_montgomery(), other.0.as_montgomery()))
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
+        crypto_bigint_helpers::pow::pow_u32(
+            x.0.inner(),
+            y,
+            *self.params.one(),
+            self.params.modulus().as_ref(),
+            self.params.mod_neg_inv(),
+        )
+        .into()
     }
-}
 
-impl<const LIMBS: usize> Hash for MontyField<LIMBS> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_montgomery().hash(state)
-    }
-}
-
-//
-// Basic arithmetic operations
-//
-
-impl<const LIMBS: usize> Neg for MontyField<LIMBS> {
-    type Output = Self;
-
-    fn neg(mut self) -> Self::Output {
-        *self.0.as_montgomery_mut() = self
-            .0
-            .as_montgomery()
-            .neg_mod(self.0.params().modulus().as_nz_ref());
-        self
-    }
-}
-
-macro_rules! impl_basic_op_forward_to_assign {
-    ($trait:ident, $method:ident, $assign_method:ident) => {
-        impl<const LIMBS: usize> $trait for MontyField<LIMBS> {
-            type Output = MontyField<LIMBS>;
-
-            #[inline(always)]
-            fn $method(self, rhs: MontyField<LIMBS>) -> Self::Output {
-                self.$method(&rhs)
-            }
-        }
-
-        impl<const LIMBS: usize> $trait<&Self> for MontyField<LIMBS> {
-            type Output = MontyField<LIMBS>;
-
-            #[inline(always)]
-            fn $method(mut self, rhs: &MontyField<LIMBS>) -> Self::Output {
-                self.$assign_method(rhs);
-                self
-            }
-        }
-
-        impl<const LIMBS: usize> $trait for &MontyField<LIMBS> {
-            type Output = MontyField<LIMBS>;
-
-            #[inline(always)]
-            fn $method(self, rhs: &MontyField<LIMBS>) -> Self::Output {
-                self.clone().$method(rhs)
-            }
-        }
-
-        impl<const LIMBS: usize> $trait<MontyField<LIMBS>> for &MontyField<LIMBS> {
-            type Output = MontyField<LIMBS>;
-
-            #[inline(always)]
-            fn $method(self, rhs: MontyField<LIMBS>) -> Self::Output {
-                self.clone().$method(&rhs)
-            }
-        }
-    };
-}
-
-impl_basic_op_forward_to_assign!(Add, add, add_assign);
-impl_basic_op_forward_to_assign!(Sub, sub, sub_assign);
-impl_basic_op_forward_to_assign!(Mul, mul, mul_assign);
-impl_basic_op_forward_to_assign!(Div, div, div_assign);
-
-impl<const LIMBS: usize> Pow<u32> for MontyField<LIMBS> {
-    type Output = Self;
-
-    fn pow(self, rhs: u32) -> Self::Output {
-        Self(self.0.pow(&crypto_bigint::Uint::<1>::from(rhs)))
-    }
-}
-
-impl<const LIMBS: usize> Inv for MontyField<LIMBS> {
-    type Output = Option<Self>;
-
-    fn inv(self) -> Self::Output {
-        Some(Self(Option::from(self.0.invert_vartime())?))
-    }
-}
-
-impl<const LIMBS: usize> Inv for &MontyField<LIMBS> {
-    type Output = Option<MontyField<LIMBS>>;
-
-    fn inv(self) -> Self::Output {
-        Some(MontyField(Option::from(self.0.invert_vartime())?))
-    }
-}
-
-//
-// Checked arithmetic operations
-// (Note: Field operations do not overflow)
-//
-
-impl<const LIMBS: usize> CheckedDiv for MontyField<LIMBS> {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn checked_div(&self, rhs: &Self) -> Option<Self> {
-        Some(self * rhs.inv()?)
-    }
-}
-
-//
-// Arithmetic assign operations
-//
-
-macro_rules! impl_op_assign_boilerplate {
-    ($trait:ident, $method:ident) => {
-        impl<const LIMBS: usize> $trait for MontyField<LIMBS> {
-            #[inline(always)]
-            fn $method(&mut self, rhs: Self) {
-                self.$method(&rhs);
-            }
-        }
-    };
-}
-
-impl_op_assign_boilerplate!(AddAssign, add_assign);
-impl_op_assign_boilerplate!(SubAssign, sub_assign);
-impl_op_assign_boilerplate!(MulAssign, mul_assign);
-impl_op_assign_boilerplate!(DivAssign, div_assign);
-
-impl<const LIMBS: usize> AddAssign<&Self> for MontyField<LIMBS> {
-    #[inline(always)]
-    fn add_assign(&mut self, rhs: &Self) {
-        *self.0.as_montgomery_mut() = self
-            .0
-            .as_montgomery()
-            .add_mod(rhs.0.as_montgomery(), self.0.params().modulus().as_nz_ref());
-    }
-}
-
-impl<const LIMBS: usize> SubAssign<&Self> for MontyField<LIMBS> {
-    #[inline(always)]
-    fn sub_assign(&mut self, rhs: &Self) {
-        *self.0.as_montgomery_mut() = self
-            .0
-            .as_montgomery()
-            .sub_mod(rhs.0.as_montgomery(), self.0.params().modulus().as_nz_ref());
-    }
-}
-
-impl<const LIMBS: usize> MulAssign<&Self> for MontyField<LIMBS> {
-    #[inline(always)]
-    fn mul_assign(&mut self, rhs: &Self) {
-        let monty_mul = crypto_bigint_helpers::mul::monty_mul(
-            self.0.as_montgomery(),
-            rhs.0.as_montgomery(),
-            self.0.params().modulus().as_ref(),
-        );
-        *self.0.as_montgomery_mut() = monty_mul;
-    }
-}
-
-impl<const LIMBS: usize> DivAssign<&Self> for MontyField<LIMBS> {
-    fn div_assign(&mut self, rhs: &Self) {
-        self.mul_assign(rhs.inv().expect("Division by zero"));
-    }
-}
-
-//
-// Aggregate operations
-//
-
-impl<const LIMBS: usize> Sum for MontyField<LIMBS> {
-    fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
-        let Some(MontyField(first)) = iter.next() else {
-            panic!("Sum of an empty iterator is not defined for MontyField");
-        };
-        Self(iter.fold(first, |acc, x| FixedMontyForm::add(&acc, &x.0)))
-    }
-}
-
-impl<'a, const LIMBS: usize> Sum<&'a Self> for MontyField<LIMBS> {
-    fn sum<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
-        let Some(MontyField(first)) = iter.next() else {
-            panic!("Sum of an empty iterator is not defined for MontyField");
-        };
-        Self(iter.fold(*first, |acc, x| FixedMontyForm::add(&acc, &x.0)))
-    }
-}
-
-impl<const LIMBS: usize> Product for MontyField<LIMBS> {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn product<I: Iterator<Item = Self>>(mut iter: I) -> Self {
-        let Some(first) = iter.next() else {
-            panic!("Product of an empty iterator is not defined for MontyField");
-        };
-        iter.fold(first, |acc, x| acc * x)
-    }
-}
-
-impl<'a, const LIMBS: usize> Product<&'a Self> for MontyField<LIMBS> {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn product<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
-        let Some(first) = iter.next() else {
-            panic!("Product of an empty iterator is not defined for MontyField");
-        };
-        iter.fold(first.clone(), |acc, x| acc * x)
-    }
+    // Assign operations use the default implementations, which delegate to the
+    // operations above (`Uint` arithmetic is not in-place anyway)
 }
 
 //
 // Conversions
 //
 
-impl<const LIMBS: usize> From<FixedMontyForm<LIMBS>> for MontyField<LIMBS> {
-    #[inline(always)]
-    fn from(value: FixedMontyForm<LIMBS>) -> Self {
-        Self(value)
-    }
-}
-
-impl<const LIMBS: usize> From<MontyField<LIMBS>> for FixedMontyForm<LIMBS> {
-    #[inline(always)]
-    fn from(value: MontyField<LIMBS>) -> Self {
-        value.0
-    }
-}
-
-impl<const LIMBS: usize> From<&MontyField<LIMBS>> for MontyField<LIMBS> {
-    fn from(value: &Self) -> Self {
-        value.clone()
-    }
-}
-
 macro_rules! impl_from_unsigned {
     ($($t:ty),* $(,)?) => {
         $(
-            impl<const LIMBS: usize>FromWithConfig<$t> for MontyField<LIMBS> {
-                fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
-                    let abs: crypto_bigint::Uint<LIMBS> = value.into();
-                    let monty_mul = crypto_bigint_helpers::mul::monty_mul(
-                        &abs,
-                        cfg.r2(),
-                        cfg.modulus(),
-                    );
-                    MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg))
-                }
-            }
-
-            impl<const LIMBS: usize>FromWithConfig<&$t> for MontyField<LIMBS> {
-                fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
-                    Self::from_with_cfg(*value, cfg)
+            impl<const LIMBS: usize> ProjectElement<$t> for MontyField<LIMBS> {
+                fn project(&self, value: &$t) -> Self::Element {
+                    let abs: crypto_bigint::Uint<LIMBS> = (*value).into();
+                    self.project(&Uint::new(abs))
                 }
             }
         )*
@@ -380,23 +166,11 @@ macro_rules! impl_from_unsigned {
 macro_rules! impl_from_signed {
     ($($t:ty),* $(,)?) => {
         $(
-            #[allow(clippy::arithmetic_side_effects)] // False alert
-            impl<const LIMBS: usize>FromWithConfig<$t> for MontyField<LIMBS> {
-                fn from_with_cfg(value: $t, cfg: &Self::Config) -> Self {
-                    let magnitude = Uint::from(value.abs_diff(0));
-                    let monty_mul = crypto_bigint_helpers::mul::monty_mul(
-                        magnitude.inner(),
-                        cfg.r2(),
-                        cfg.modulus(),
-                    );
-                    let result = MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg));
-                    if value.is_negative() { -result } else { result }
-                }
-            }
-
-            impl<const LIMBS: usize>FromWithConfig<&$t> for MontyField<LIMBS> {
-                fn from_with_cfg(value: &$t, cfg: &Self::Config) -> Self {
-                    Self::from_with_cfg(*value, cfg)
+            impl<const LIMBS: usize> ProjectElement<$t> for MontyField<LIMBS> {
+                fn project(&self, value: &$t) -> Self::Element {
+                    let magnitude: crypto_bigint::Uint<LIMBS> = value.abs_diff(0).into();
+                    let magnitude = self.project(&Uint::new(magnitude));
+                    if value.is_negative() { self.neg(&magnitude) } else { magnitude }
                 }
             }
         )*
@@ -406,171 +180,105 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
-impl<const LIMBS: usize> FromWithConfig<bool> for MontyField<LIMBS> {
-    fn from_with_cfg(value: bool, cfg: &Self::Config) -> Self {
-        let value = if value {
-            crypto_bigint::Uint::one()
+impl<const LIMBS: usize> ProjectElement<bool> for MontyField<LIMBS> {
+    fn project(&self, value: &bool) -> Self::Element {
+        if *value { self.one() } else { self.zero() }
+    }
+}
+
+impl<const LIMBS: usize> ProjectElement<Boolean> for MontyField<LIMBS> {
+    #[inline(always)]
+    fn project(&self, value: &Boolean) -> Self::Element {
+        self.project(&value.inner())
+    }
+}
+
+impl<const LIMBS: usize, const LIMBS2: usize> ProjectElement<Int<LIMBS2>> for MontyField<LIMBS> {
+    fn project(&self, value: &Int<LIMBS2>) -> Self::Element {
+        let abs = self.project(&Uint::new(value.inner().abs()));
+        if value.is_negative() {
+            self.neg(&abs)
         } else {
-            Zero::zero()
-        };
-        Self(FixedMontyForm::new(&value, cfg))
+            abs
+        }
     }
 }
 
-impl<const LIMBS: usize> FromWithConfig<&bool> for MontyField<LIMBS> {
-    fn from_with_cfg(value: &bool, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(*value, cfg)
-    }
-}
-
-impl<const LIMBS: usize> FromWithConfig<Boolean> for MontyField<LIMBS> {
-    fn from_with_cfg(value: Boolean, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(*value, cfg)
-    }
-}
-
-impl<const LIMBS: usize> FromWithConfig<&Boolean> for MontyField<LIMBS> {
-    fn from_with_cfg(value: &Boolean, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(*value, cfg)
-    }
-}
-
-impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<Int<LIMBS2>> for MontyField<LIMBS> {
-    fn from_with_cfg(value: Int<LIMBS2>, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(&value, cfg)
-    }
-}
-
-impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Int<LIMBS2>> for MontyField<LIMBS> {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn from_with_cfg(value: &Int<LIMBS2>, cfg: &Self::Config) -> Self {
-        let mut abs = value.inner().abs();
-        if LIMBS < LIMBS2 {
-            abs = abs.rem(cfg.modulus().get().resize::<LIMBS2>())
-        };
-        let abs = abs.resize();
-
-        let monty_mul = crypto_bigint_helpers::mul::monty_mul(&abs, cfg.r2(), cfg.modulus());
-        let result = MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg));
-
-        if value.is_negative() { -result } else { result }
-    }
-}
-
-impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<Uint<LIMBS2>> for MontyField<LIMBS> {
-    fn from_with_cfg(value: Uint<LIMBS2>, cfg: &Self::Config) -> Self {
-        Self::from_with_cfg(&value, cfg)
-    }
-}
-
-impl<const LIMBS: usize, const LIMBS2: usize> FromWithConfig<&Uint<LIMBS2>> for MontyField<LIMBS> {
-    #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn from_with_cfg(value: &Uint<LIMBS2>, cfg: &Self::Config) -> Self {
+impl<const LIMBS: usize, const LIMBS2: usize> ProjectElement<Uint<LIMBS2>> for MontyField<LIMBS> {
+    /// Convert the given integer into the Montgomery domain.
+    fn project(&self, value: &Uint<LIMBS2>) -> Self::Element {
         let value: crypto_bigint::Uint<LIMBS> = if LIMBS >= LIMBS2 {
             value.inner().resize()
         } else {
+            // The value is wider than the modulus: reduce it first, so that
+            // the resize below cannot truncate.
             value
                 .inner()
-                .rem(&NonZero::<crypto_bigint::Uint<LIMBS>>::new_unwrap(
-                    cfg.modulus().get(),
+                .rem(&NonZero::<crypto_bigint::Uint<LIMBS2>>::new_unwrap(
+                    self.params.modulus().as_ref().resize::<LIMBS2>(),
                 ))
                 .resize()
         };
 
-        let monty_mul = crypto_bigint_helpers::mul::monty_mul(&value, cfg.r2(), cfg.modulus());
-        MontyField(FixedMontyForm::from_montgomery(monty_mul, cfg))
+        // Convert into the Montgomery domain
+        crypto_bigint_helpers::mul::monty_mul(
+            &value,
+            self.params.r2(),
+            self.params.modulus().as_ref(),
+        )
+        .into()
     }
 }
 
 //
-// Semiring, Ring and Field
+// Field stuff
 //
 
-impl<const LIMBS: usize> Semiring for MontyField<LIMBS> {}
-
-impl<const LIMBS: usize> Ring for MontyField<LIMBS> {}
-
-impl<const LIMBS: usize> Field for MontyField<LIMBS> {
-    type Inner = Uint<LIMBS>;
-    type Integer = Uint<LIMBS>;
-
-    #[inline(always)]
-    fn inner(&self) -> &Self::Inner {
-        Uint::new_ref(self.0.as_montgomery())
+impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
+    fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
+        let Some(modulus) = Odd::new(*modulus.inner()).into_option() else {
+            return Err(FieldError::InvalidModulus);
+        };
+        Ok(Self {
+            params: FixedMontyParams::new(modulus),
+        })
     }
 
-    #[inline(always)]
-    fn inner_mut(&mut self) -> &mut Self::Inner {
-        Uint::new_ref_mut(self.0.as_montgomery_mut())
-    }
-
-    #[inline(always)]
-    fn into_inner(self) -> Self::Inner {
-        Uint::new(self.0.to_montgomery())
-    }
-
-    #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
-        Uint::new(self.0.retrieve())
-    }
-}
-
-impl<const LIMBS: usize> HasPrimeFieldConfig for MontyField<LIMBS> {
-    type Config = FixedMontyParams<LIMBS>;
-
-    fn cfg(&self) -> &Self::Config {
-        self.0.params()
-    }
-}
-
-impl<const LIMBS: usize> PrimeField for MontyField<LIMBS> {
-    fn modulus(cfg: &Self::Config) -> Self::Integer {
-        Uint::new(cfg.modulus().get())
+    fn modulus(&self) -> Self::Integer {
+        Uint::new(self.params.modulus().get())
     }
 
     #[allow(clippy::arithmetic_side_effects)] // False alert
-    fn modulus_minus_one_div_two(cfg: &Self::Config) -> Self::Inner {
-        let value = cfg.modulus().get();
+    fn modulus_minus_one_div_two(&self) -> Self::Integer {
+        let value = self.params.modulus().get();
         Uint::new(
             (value - crypto_bigint::Uint::one())
                 / NonZero::new(crypto_bigint::Uint::<LIMBS>::from(2_u8)).unwrap(),
         )
     }
+}
 
-    fn make_cfg(modulus: &Self::Integer) -> Result<Self::Config, FieldError> {
-        let Some(modulus) = Odd::new(*modulus.inner()).into_option() else {
-            return Err(FieldError::InvalidModulus);
-        };
-        Ok(FixedMontyParams::new(modulus))
-    }
+impl<const LIMBS: usize> WithAssociatedInteger for MontyField<LIMBS> {
+    type Integer = Uint<LIMBS>;
+}
 
-    fn new_unchecked_with_cfg(inner: Self::Inner, cfg: &Self::Config) -> Self {
-        Self(FixedMontyForm::from_montgomery(inner.into_inner(), cfg))
-    }
-
-    fn is_zero(value: &Self) -> bool {
-        value.0.as_montgomery().is_zero_vartime()
-    }
-
-    fn zero_with_cfg(cfg: &Self::Config) -> Self {
-        Self(FixedMontyForm::zero(cfg))
-    }
-
-    fn one_with_cfg(cfg: &Self::Config) -> Self {
-        Self(FixedMontyForm::one(cfg))
+impl<const LIMBS: usize> LiftToIntegerDynamic for MontyField<LIMBS> {
+    /// Retrieves the integer currently encoded in this [`MontyField`],
+    /// guaranteed to be reduced.
+    #[inline(always)]
+    fn lift_to_integer(&self, value: &Self::Element) -> Self::Integer {
+        let mut out = crypto_bigint::Uint::<LIMBS>::ZERO;
+        crypto_bigint_helpers::monty_retrieve_inner(
+            value.0.inner().as_limbs(),
+            out.as_mut_limbs(),
+            self.params.modulus().as_ref().as_limbs(),
+            self.params.mod_neg_inv(),
+        );
+        Uint::new(out)
     }
 }
 
-//
-// Zeroize
-//
-
-#[cfg(feature = "zeroize")]
-impl<const LIMBS: usize> zeroize::Zeroize for MontyField<LIMBS> {
-    fn zeroize(&mut self) {
-        self.0.zeroize()
-    }
-}
+// TODO: Do we want to zeroize the modulus?
 
 //
 // Predefined fields of various sizes for convenience
@@ -613,201 +321,164 @@ mod tests {
     use super::*;
     use crate::ensure_type_implements_trait;
     use alloc::vec;
+    use core::cmp::Ordering;
     use crypto_bigint::U64;
-    use num_traits::{ConstOne, ConstZero, Pow};
 
     const LIMBS: usize = 4;
     type F = F256;
 
+    #[test]
+    fn ensure_traits() {
+        ensure_type_implements_trait!(F, FieldConfig);
+    }
+
     //
     // Test helpers
     //
-    fn test_config() -> FixedMontyParams<LIMBS> {
+
+    fn make_f() -> F {
         // Using a 256-bit prime 2^256 - 2^32 - 977 (secp256k1 field prime)
         let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
         );
         let modulus = Odd::new(modulus).expect("modulus should be odd");
-        FixedMontyParams::new(modulus)
+        F::wrap(FixedMontyParams::new(modulus))
     }
 
     #[test]
     fn new_with_cfg_correct() {
-        let cfg = test_config();
+        let f = make_f();
 
         // `modulus + 1` should reduce to one.
-        let x = Uint::<{ F256::LIMBS }>::from_be_hex(
+        let x = Uint::<LIMBS>::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
         );
-        assert_eq!(F::from_with_cfg(x, &cfg), F::one_with_cfg(&cfg));
+        assert_eq!(f.project(&x), f.one());
 
         // `modulus` itself should reduce to zero.
-        let modulus = F::modulus(&cfg);
-        assert_eq!(F::from_with_cfg(modulus, &cfg), F::zero_with_cfg(&cfg));
+        let modulus = f.modulus();
+        assert_eq!(f.project(&modulus), f.zero());
 
         // Lifting to integer and projecting back yields the original element.
         for x in [
-            F::zero_with_cfg(&cfg),
-            F::one_with_cfg(&cfg),
-            F::from_with_cfg(2_u64, &cfg),
-            F::from_with_cfg(123456789_u64, &cfg),
+            f.zero(),
+            f.one(),
+            f.project(&2_u64),
+            f.project(&123456789_u64),
         ] {
-            assert_eq!(F::from_with_cfg(x.lift_to_integer(), &cfg), x);
+            assert_eq!(f.project(&f.lift_to_integer(&x)), x);
         }
-    }
-
-    fn from_u64(value: u64) -> F {
-        F::from_with_cfg(value, &test_config())
-    }
-
-    fn from_i64(value: i64) -> F {
-        F::from_with_cfg(value, &test_config())
-    }
-
-    fn zero() -> F {
-        F::zero_with_cfg(&test_config())
-    }
-
-    fn one() -> F {
-        F::one_with_cfg(&test_config())
-    }
-
-    #[test]
-    fn ensure_blanket_traits() {
-        // NB: this ensures `PrimeField` implementation too!
-        ensure_type_implements_trait!(F, FromPrimitiveWithConfig);
     }
 
     #[test]
     fn zero_one_basics() {
-        let z = zero();
-        assert!(F::is_zero(&z));
-        let o = one();
-        assert!(!F::is_zero(&o));
+        let f = make_f();
+        let z = f.zero();
+        assert!(f.is_zero(&z));
+        let o = f.one();
+        assert!(!f.is_zero(&o));
         assert_ne!(z, o);
     }
 
     #[test]
     fn basic_operations() {
-        // Negation
-        let a = from_u64(9);
-        let neg_a = -a.clone();
-        assert_eq!(&a + &neg_a, zero());
+        let f = make_f();
 
-        let a = from_u64(10);
-        let b = from_u64(5);
+        // Negation
+        let a = f.project(&9);
+        let neg_a = f.neg(&a);
+        assert_eq!(f.add(&a, &neg_a), f.zero());
+
+        let a = f.project(&10);
+        let b = f.project(&5);
 
         // Addition
-        let c = a.clone() + b.clone();
-        assert_eq!(c, from_u64(15));
+        let c = f.add(&a, &b);
+        assert_eq!(c, f.project(&15));
 
         // Subtraction
-        let d = a.clone() - b.clone();
-        assert_eq!(d, from_u64(5));
+        let d = f.sub(&a, &b);
+        assert_eq!(d, f.project(&5));
 
         // Multiplication
-        let e = a.clone() * b.clone();
-        assert_eq!(e, from_u64(50));
+        let e = f.mul(&a, &b);
+        assert_eq!(e, f.project(&50));
 
         // Division
-        let num = from_u64(11);
-        let den = from_u64(5);
-        let q = num.clone() / den.clone();
-        assert_eq!(&q * &den, num);
+        let num = f.project(&11);
+        let den = f.project(&5);
+        let q = f.div(&num, &den);
+        assert_eq!(f.mul(&q, &den), num);
     }
 
     #[test]
     fn basic_operations_overflow() {
-        let params = test_config();
-        let mod_minus_one = Uint::new(params.modulus().get() - crypto_bigint::Uint::one());
-        let mod_minus_one = F::from_with_cfg(mod_minus_one, &params);
+        let f = make_f();
+
+        let mod_minus_one = Uint::new(f.params.modulus().get() - crypto_bigint::Uint::one());
+        let mod_minus_one = f.project(&mod_minus_one);
 
         // Negation
-        let res = -mod_minus_one.clone();
-        assert_eq!(res, one());
+        let res = f.neg(&mod_minus_one);
+        assert_eq!(res, f.one());
 
         // Addition
-        let res = mod_minus_one.clone() + one();
-        assert_eq!(res, zero());
+        let res = f.add(&mod_minus_one, &f.one());
+        assert_eq!(res, f.zero());
 
         // Subtraction
-        let res = zero() - one();
+        let res = f.sub(&f.zero(), &f.one());
         assert_eq!(res, mod_minus_one);
 
         // Multiplication
-        let res = mod_minus_one.clone() * from_u64(2);
-        assert_eq!(res, mod_minus_one.clone() - one());
+        let res = f.mul(&mod_minus_one, &f.project(&2));
+        assert_eq!(res, f.sub(&mod_minus_one, &f.one()));
 
-        let res = mod_minus_one.clone() * mod_minus_one.clone();
-        assert_eq!(res, one());
+        let res = f.mul(&mod_minus_one, &mod_minus_one);
+        assert_eq!(res, f.one());
 
         // Division
-        let res = one() / mod_minus_one.clone();
+        let res = f.div(&f.one(), &mod_minus_one);
         assert_eq!(res, mod_minus_one);
     }
 
     #[test]
     fn add_wrapping() {
-        let a = from_i64(-100);
-        let b = from_u64(105);
-        let c = a + b;
-        let d = from_u64(5);
+        let f = make_f();
+
+        let a = f.project(&-100);
+        let b = f.project(&105);
+        let c = f.add(&a, &b);
+        let d = f.project(&5);
         assert_eq!(c, d);
-    }
-
-    #[allow(clippy::op_ref)]
-    #[test]
-    fn reference_operations() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        // Addition
-        let c = &a + &b;
-        assert_eq!(c, from_u64(15));
-
-        // Subtraction
-        let d = &a - &b;
-        assert_eq!(d, from_u64(5));
-
-        // Multiplication
-        let e = &a * &b;
-        assert_eq!(e, from_u64(50));
-
-        // Division
-        let num = from_u64(11);
-        let den = from_u64(5);
-        let q = &num / &den;
-        assert_eq!(&q * &den, num);
     }
 
     #[test]
     fn from_bool() {
-        let cfg = test_config();
-        assert_eq!(F::from_with_cfg(true, &cfg), one());
-        assert_eq!(F::from_with_cfg(false, &cfg), zero());
+        let f = make_f();
 
-        let t = F::from_with_cfg(true, &cfg);
-        let f = F::from_with_cfg(false, &cfg);
-        assert_eq!(t, one());
-        assert_eq!(f, zero());
+        assert_eq!(f.project(&true), f.one());
+        assert_eq!(f.project(&false), f.zero());
     }
 
     #[test]
     fn from_unsigned_and_signed() {
         const LIMBS: usize = U64::LIMBS;
         type F = F64;
-        let cfg = F::make_cfg(&Uint::from(10064419296686275259_u64)).unwrap();
+
+        // Using a 64-bit prime
+        let f = F::new(&Uint::from(10064419296686275259_u64)).unwrap();
         macro_rules! to_field {
             ($x:expr) => {
-                F::from_with_cfg($x, &cfg)
+                f.project(&$x)
             };
         }
-        let zero = F::zero_with_cfg(&cfg);
-        let one = F::one_with_cfg(&cfg);
+        let zero = f.zero();
+        let one = f.one();
         assert_eq!(to_field!(0), zero);
         assert_eq!(to_field!(1), one);
-        assert_eq!(to_field!(-1) + one, zero);
-        assert_eq!(to_field!(-5) + F::from_with_cfg(5, &cfg), zero);
+        assert_eq!(f.add(&to_field!(-1), &one), zero);
+        assert_eq!(f.add(&to_field!(-5), &f.project(&5)), zero);
 
         // u64 maximum value (hand-calculated)
         assert_eq!(
@@ -829,25 +500,21 @@ mod tests {
 
         // Verify property: i64::MIN + |i64::MIN| = 0
         let i64_min_abs = to_field!(i64::MIN.unsigned_abs());
-        assert_eq!(to_field!(i64::MIN) + i64_min_abs, zero);
+        assert_eq!(f.add(&to_field!(i64::MIN), &i64_min_abs), zero);
     }
 
     #[test]
     fn from_uint_and_int() {
         const LIMBS: usize = U64::LIMBS;
         type F = F64;
-        let cfg = F::make_cfg(&Uint::from(10064419296686275259_u64)).unwrap();
+
+        // Using a 64-bit prime
+        let f = F::new(&Uint::from(10064419296686275259_u64)).unwrap();
         macro_rules! to_field {
             ($x:expr) => {
-                F::from_with_cfg($x, &cfg)
+                f.project(&$x)
             };
         }
-
-        assert_eq!(
-            Int::<LIMBS>::MIN.into_inner().abs(),
-            Uint::<LIMBS>::MAX.into_inner() / Uint::<LIMBS>::from_u64(2).into_inner()
-                + Uint::ONE.into_inner()
-        );
 
         let u: Uint<LIMBS> = Uint::from(123_u64);
         assert_eq!(to_field!(u), to_field!(123_u64));
@@ -855,327 +522,195 @@ mod tests {
         let i: Int<LIMBS> = Int::from(123_i64);
         assert_eq!(to_field!(i), to_field!(123_u64));
 
-        assert_eq!(to_field!(Uint::<LIMBS>::ZERO), F::zero_with_cfg(&cfg));
+        assert_eq!(to_field!(Uint::<LIMBS>::from(0_u64)), f.zero());
 
-        // Uint maximum value (hand-calculated)
-        assert_eq!(
-            to_field!(u64::MAX),
-            to_field!(Uint::<LIMBS>::from_be_hex("7453fff9266d8544"))
-        );
+        // Negative Int encodes to the additive inverse
+        let i: Int<LIMBS> = Int::from(-123_i64);
+        assert_eq!(f.add(&to_field!(i), &to_field!(123_u64)), f.zero());
 
-        // Int maximum value (hand-calculated)
+        // A Uint wider than the modulus is reduced before encoding:
+        // 2^64 mod m = (u64::MAX mod m) + 1 (hand-calculated)
+        let wide = Uint::<{ 2 * LIMBS }>::from_be_hex("00000000000000010000000000000000");
         assert_eq!(
-            to_field!(i64::MAX),
-            to_field!(Uint::<LIMBS>::from_be_hex("7fffffffffffffff"))
-        );
-
-        // Int minimum value (hand-calculated)
-        assert_eq!(
-            to_field!(i64::MIN),
-            to_field!(Uint::<LIMBS>::from_be_hex("0bac0006d9927abb"))
+            to_field!(wide),
+            to_field!(Uint::<LIMBS>::from_be_hex("7453fff9266d8545"))
         );
     }
 
     #[test]
     fn assign_operations() {
+        let f = make_f();
+
         // Addition
-        let mut a = from_u64(5);
-        a += from_u64(6);
-        assert_eq!(a, from_u64(11));
+        let mut a = f.project(&5);
+        f.add_assign(&mut a, &f.project(&6));
+        assert_eq!(a, f.project(&11));
 
         // Subtraction
-        let mut a = from_u64(20);
-        a -= from_u64(7);
-        assert_eq!(a, from_u64(13));
+        let mut a = f.project(&20);
+        f.sub_assign(&mut a, &f.project(&7));
+        assert_eq!(a, f.project(&13));
 
         // Multiplication
-        let mut a = from_u64(11);
-        a *= from_u64(3);
-        assert_eq!(a, from_u64(33));
+        let mut a = f.project(&11);
+        f.mul_assign(&mut a, &f.project(&3));
+        assert_eq!(a, f.project(&33));
 
         // Division
-        let mut a = from_u64(20);
-        let b = from_u64(4);
-        a /= b;
-        assert_eq!(&a * &from_u64(4), from_u64(20));
+        let mut a = f.project(&20);
+        let b = f.project(&4);
+        f.div_assign(&mut a, &b);
+        assert_eq!(f.mul(&a, &b), f.project(&20));
     }
 
     #[test]
     #[should_panic(expected = "Division by zero")]
     fn div_by_zero_panics() {
-        let a = from_u64(7);
-        let zero = zero();
-        let _ = a / zero;
+        let f = make_f();
+
+        let a = f.project(&7);
+        let zero = f.zero();
+        let _ = f.div(&a, &zero);
     }
 
     #[test]
     fn pow_operation() {
+        let f = make_f();
+
         // Test basic exponentiation
-        let base = from_u64(2);
+        let base = f.project(&2);
 
         // 2^0 = 1
-        assert_eq!(base.clone().pow(0), one());
+        assert_eq!(f.pow_u32(&base, 0), f.one());
 
         // 2^1 = 2
-        assert_eq!(base.clone().pow(1), base);
+        assert_eq!(f.pow_u32(&base, 1), base);
 
         // 2^3 = 8
-        assert_eq!(base.clone().pow(3), from_u64(8));
+        assert_eq!(f.pow_u32(&base, 3), f.project(&8));
 
         // 2^10 = 1024
-        assert_eq!(base.clone().pow(10), from_u64(1024));
+        assert_eq!(f.pow_u32(&base, 10), f.project(&1024));
 
         // Test with different base
-        let base = from_u64(3);
+        let base = f.project(&3);
 
         // 3^4 = 81
-        assert_eq!(base.clone().pow(4), from_u64(81));
+        assert_eq!(f.pow_u32(&base, 4), f.project(&81));
 
         // Test with base 1
-        let base = one();
-        assert_eq!(base.clone().pow(1000), one());
+        let base = f.one();
+        assert_eq!(f.pow_u32(&base, 1000), f.one());
 
         // Test with base 0
-        let base = zero();
-        assert_eq!(base.clone().pow(0), one()); // 0^0 = 1 by convention
-        assert_eq!(base.clone().pow(10), zero()); // 0^n = 0 for n > 0
+        let base = f.zero();
+        assert_eq!(f.pow_u32(&base, 0), f.one()); // 0^0 = 1 by convention
+        assert_eq!(f.pow_u32(&base, 10), f.zero()); // 0^n = 0 for n > 0
     }
 
     #[test]
     fn inv_operation() {
-        let a = from_u64(5);
-        let inv_a = a.clone().inv().unwrap();
-        assert_eq!(&a * &inv_a, one());
+        let f = make_f();
+
+        let a = f.project(&5);
+        let inv_a = f.inv(&a).unwrap();
+        assert_eq!(f.mul(&a, &inv_a), f.one());
 
         // Test that zero has no inverse
-        let zero = zero();
-        assert!(zero.inv().is_none());
-    }
-
-    #[test]
-    fn checked_neg() {
-        // Test with positive number
-        let a = from_u64(10);
-        let neg_a = a.checked_neg().unwrap();
-        assert_eq!(neg_a, from_i64(-10));
-
-        // Test with negative number
-        let b = from_i64(-5);
-        let neg_b = b.checked_neg().unwrap();
-        assert_eq!(neg_b, from_u64(5));
-
-        // Test with zero
-        let zero_val = zero();
-        let neg_zero = zero_val.checked_neg().unwrap();
-        assert_eq!(neg_zero, zero());
-    }
-
-    #[test]
-    fn checked_add() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        let c = a.checked_add(&b).unwrap();
-        assert_eq!(c, from_u64(15));
-    }
-
-    #[test]
-    fn checked_sub() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        let d = a.checked_sub(&b).unwrap();
-        assert_eq!(d, from_u64(5));
-    }
-
-    #[test]
-    fn checked_mul() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-
-        let e = a.checked_mul(&b).unwrap();
-        assert_eq!(e, from_u64(50));
+        let zero = f.zero();
+        assert!(f.inv(&zero).is_none());
     }
 
     #[test]
     fn checked_div() {
-        let a = from_u64(10);
-        let b = from_u64(5);
-        let zero = zero();
+        let f = make_f();
+
+        let a = f.project(&10);
+        let b = f.project(&5);
+        let zero = f.zero();
 
         // Normal division
-        let c = a.checked_div(&b).unwrap();
-        assert_eq!(&c * &b, a);
+        let c = f.checked_div(&a, &b).unwrap();
+        assert_eq!(f.mul(&c, &b), a);
 
         // Division by zero
-        assert!(a.checked_div(&zero).is_none());
-    }
-
-    #[allow(clippy::op_ref)]
-    #[test]
-    fn ref_and_value_combinations_add_sub_mul() {
-        let a = from_u64(42);
-        let b = from_u64(123);
-
-        let r1 = &a + &b;
-        let a1 = from_u64(42);
-        let b1 = from_u64(123);
-        let r2 = a1 + b1;
-        let a2 = from_u64(42);
-        let b2 = from_u64(123);
-        let r3 = a2 + &b2;
-        let a3 = from_u64(42);
-        let b3 = from_u64(123);
-        let r4 = &a3 + b3;
-        assert_eq!(r1, r2);
-        assert_eq!(r1, r3);
-        assert_eq!(r1, r4);
-
-        let a = from_u64(88);
-        let b = from_u64(59);
-        let s1 = &a - &b;
-        let a1 = from_u64(88);
-        let b1 = from_u64(59);
-        let s2 = a1 - b1;
-        let a2 = from_u64(88);
-        let b2 = from_u64(59);
-        let s3 = a2 - &b2;
-        let a3 = from_u64(88);
-        let b3 = from_u64(59);
-        let s4 = &a3 - b3;
-        assert_eq!(s1, s2);
-        assert_eq!(s1, s3);
-        assert_eq!(s1, s4);
-
-        let a = from_u64(9);
-        let b = from_u64(14);
-        let m1 = &a * &b;
-        let a1 = from_u64(9);
-        let b1 = from_u64(14);
-        let m2 = a1 * b1;
-        let a2 = from_u64(9);
-        let b2 = from_u64(14);
-        let m3 = a2 * &b2;
-        let a3 = from_u64(9);
-        let b3 = from_u64(14);
-        let m4 = &a3 * b3;
-        assert_eq!(m1, m2);
-        assert_eq!(m1, m3);
-        assert_eq!(m1, m4);
-    }
-
-    #[test]
-    fn assign_ops_with_refs_and_val() {
-        let mut a = from_u64(100);
-        let b = from_u64(50);
-        a += b;
-        assert_eq!(a, from_u64(150));
-
-        let mut c = from_u64(100);
-        let d = from_u64(50);
-        c += &d;
-        assert_eq!(c, from_u64(150));
-
-        let mut e = from_u64(100);
-        let f = from_u64(30);
-        e -= f;
-        assert_eq!(e, from_u64(70));
-
-        let mut g = from_u64(100);
-        let h = from_u64(30);
-        g -= &h;
-        assert_eq!(g, from_u64(70));
-
-        let mut i = from_u64(10);
-        let j = from_u64(5);
-        i *= j;
-        assert_eq!(i, from_u64(50));
-
-        let mut k = from_u64(10);
-        let l = from_u64(5);
-        k *= &l;
-        assert_eq!(k, from_u64(50));
+        assert!(f.checked_div(&a, &zero).is_none());
     }
 
     #[test]
     fn aggregate_operations() {
-        // Sum
-        let values = vec![from_u64(1), from_u64(2), from_u64(3)];
-        let sum: F = values.iter().sum();
-        assert_eq!(sum, from_u64(6));
+        let f = make_f();
 
-        let sum2: F = values.into_iter().sum();
-        assert_eq!(sum2, from_u64(6));
+        // Sum
+        let values = vec![f.project(&1), f.project(&2), f.project(&3)];
+        let sum = f.sum_refs(values.iter());
+        assert_eq!(sum, f.project(&6));
+
+        let sum2 = f.sum(values.into_iter());
+        assert_eq!(sum2, f.project(&6));
 
         // Product
-        let values = vec![from_u64(2), from_u64(3), from_u64(4)];
-        let product: F = values.iter().product();
-        assert_eq!(product, from_u64(24));
+        let values = vec![f.project(&2), f.project(&3), f.project(&4)];
+        let product = f.product_refs(values.iter());
+        assert_eq!(product, f.project(&24));
 
-        let product2: F = values.into_iter().product();
-        assert_eq!(product2, from_u64(24));
+        let product2 = f.product(values.into_iter());
+        assert_eq!(product2, f.project(&24));
 
-        // Test empty collections panic
-        // Note: MontyField doesn't have a default config, so empty
-        // iterators must panic
+        // Empty iterators yield the respective identity elements
+        assert_eq!(f.sum(core::iter::empty()), f.zero());
+        assert_eq!(f.product(core::iter::empty()), f.one());
     }
 
     #[test]
     fn conversions() {
-        let cfg = test_config();
+        let f = make_f();
 
-        // Test FromWithConfig for BoxedUint
-        let f = F::from_with_cfg(123_u64, &cfg);
-        assert_eq!(f, from_u64(123));
-
-        // Test inner() and cfg()
-        let value = from_u64(456);
-        let _inner_ref = value.inner();
-        let _cfg_ref = value.cfg();
+        // Test EncodeElement for Uint
+        let u = Uint::<LIMBS>::from(123_u64);
+        let a = f.project(&u);
+        assert_eq!(a, f.project(&123_u64));
     }
 
     #[test]
     fn from_primitive() {
-        let cfg = test_config();
+        let f = make_f();
 
-        // Test FromWithConfig for various types
-        let a = F::from_with_cfg(42_u8, &cfg);
-        assert_eq!(a, from_u64(42));
+        // Unsigned types
+        assert_eq!(f.project(&42_u8), f.project(&42_u64));
+        assert_eq!(f.project(&12345_u16), f.project(&12345_u64));
+        assert_eq!(f.project(&1234567890_u32), f.project(&1234567890_u64));
+        assert_eq!(
+            f.project(&1234567890123456789_u64),
+            f.project(&1234567890123456789_u128)
+        );
 
-        let b = F::from_with_cfg(12345_u16, &cfg);
-        assert_eq!(b, from_u64(12345));
-
-        let c = F::from_with_cfg(1234567890_u32, &cfg);
-        assert_eq!(c, from_u64(1234567890));
-
-        let d = F::from_with_cfg(1234567890123456789_u64, &cfg);
-        assert_eq!(d, from_u64(1234567890123456789));
-
-        let e = F::from_with_cfg(-42_i8, &cfg);
-        assert_eq!(e, from_i64(-42));
-
-        let f = F::from_with_cfg(-12345_i16, &cfg);
-        assert_eq!(f, from_i64(-12345));
-
-        let g = F::from_with_cfg(-1234567_i32, &cfg);
-        assert_eq!(g, from_i64(-1234567));
-
-        let h = F::from_with_cfg(-1234567890123456789_i64, &cfg);
-        assert_eq!(h, from_i64(-1234567890123456789));
+        // Signed types
+        assert_eq!(f.project(&-42_i8), f.project(&-42_i64));
+        assert_eq!(f.project(&-12345_i16), f.project(&-12345_i64));
+        assert_eq!(f.project(&-1234567_i32), f.project(&-1234567_i64));
+        assert_eq!(
+            f.project(&-1234567890123456789_i64),
+            f.project(&-1234567890123456789_i128)
+        );
     }
 
     #[test]
     fn clone_works() {
-        let a = from_u64(42);
+        let f = make_f();
+
+        let a = f.project(&42);
         let b = a.clone();
         assert_eq!(a, b);
     }
 
     #[test]
     fn equality_and_ordering() {
-        let a = from_u64(10);
-        let b = from_u64(10);
-        let c = from_u64(20);
+        let f = make_f();
+
+        let a = f.project(&10);
+        let b = f.project(&10);
+        let c = f.project(&20);
 
         // Test equality
         assert_eq!(a, b);
@@ -1190,7 +725,7 @@ mod tests {
         assert!(a >= b);
 
         // Verify transitivity of ordering
-        let d = from_u64(30);
+        let d = f.project(&30);
         if a < c && c < d {
             assert!(a < d);
         }
@@ -1217,8 +752,10 @@ mod tests {
             }
         }
 
-        let a = from_u64(42);
-        let b = from_u64(42);
+        let f = make_f();
+
+        let a = f.project(&42);
+        let b = f.project(&42);
 
         let mut hasher_a = TestHasher { state: 0 };
         a.hash(&mut hasher_a);
@@ -1235,12 +772,35 @@ mod tests {
     // MontyField-specific tests
 
     #[test]
+    fn pow_matches_crypto_bigint() {
+        let f = make_f();
+
+        for (base, exp) in [
+            (0_u64, 0_u32),
+            (0, 7),
+            (1, 1000),
+            (2, 10),
+            (3, 251),
+            (123456789, 1),
+            (123456789, u32::MAX),
+        ] {
+            let x = f.project(&base);
+            let expected = FixedMontyForm::from_montgomery(*x.0.inner(), &f.params)
+                .pow(&crypto_bigint::Uint::<1>::from(exp));
+            assert_eq!(
+                f.pow_u32(&x, exp).0.inner(),
+                expected.as_montgomery(),
+                "{base}^{exp} diverges from FixedMontyForm::pow"
+            );
+        }
+    }
+
+    #[test]
     fn prime_field_methods() {
-        let a = from_u64(42);
-        let cfg = a.cfg();
+        let f = make_f();
 
         // Test that we can get modulus
-        let modulus = F::modulus(cfg);
+        let modulus = f.modulus();
         assert_eq!(
             modulus,
             Uint::new(crypto_bigint::Uint::<LIMBS>::from_be_hex(
@@ -1249,40 +809,40 @@ mod tests {
         );
 
         // Test modulus_minus_one_div_two
-        let m_minus_1_div_2 = F::modulus_minus_one_div_two(cfg);
+        let m_minus_1_div_2 = f.modulus_minus_one_div_two();
         assert_eq!(
             m_minus_1_div_2,
             Uint::new(
                 (crypto_bigint::Uint::<LIMBS>::from_be_hex(
                     "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
                 ) - crypto_bigint::Uint::one())
-                    / crypto_bigint::Uint::<LIMBS>::from(2u64)
+                    / NonZero::new(crypto_bigint::Uint::<LIMBS>::from(2u64)).unwrap()
             )
         );
 
-        // Test zero_with_cfg and one_with_cfg
-        let z = F::zero_with_cfg(cfg);
-        assert!(F::is_zero(&z));
-        let o = F::one_with_cfg(cfg);
-        assert!(!F::is_zero(&o));
+        // Test zero and one
+        let z = f.zero();
+        assert!(f.is_zero(&z));
+        let o = f.one();
+        assert!(!f.is_zero(&o));
     }
 
     #[test]
-    fn make_cfg_works() {
+    fn new_works() {
         let modulus = Uint::new(crypto_bigint::Uint::<LIMBS>::from_be_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
         ));
-        let cfg = F::make_cfg(&modulus).expect("Should create config");
+        let f = F::new(&modulus).expect("Should create config");
 
         // Create a field element using this config
-        let a = F::from_with_cfg(123_u64, &cfg);
-        assert_eq!(a, from_u64(123));
+        let a = f.project(&123_u64);
+        assert_eq!(a, f.project(&123));
     }
 
     #[test]
-    fn make_cfg_rejects_even_modulus() {
+    fn new_rejects_even_modulus() {
         let even_modulus = Uint::<LIMBS>::from(42_u64);
-        let result = F::make_cfg(&even_modulus);
+        let result = F::new(&even_modulus);
         assert!(result.is_err());
     }
 }

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{IntRing, Wrapper, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use crate::{
+    IntRing, Wrapper, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    helpers::crypto_bigint as helpers,
+};
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
     BitOps, Limb, NonZero, Odd, Word,
@@ -151,21 +154,16 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
         let inverted = inverted?;
 
         let r2 = self.params.r2();
-        let x_inv = crypto_bigint_helpers::mul::monty_mul(&inverted, r2, modulus.as_ref());
-        Some(crypto_bigint_helpers::mul::monty_mul(&x_inv, r2, modulus.as_ref()).into())
+        let x_inv = helpers::mul::monty_mul(&inverted, r2, modulus.as_ref());
+        Some(helpers::mul::monty_mul(&x_inv, r2, modulus.as_ref()).into())
     }
 
     fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
-        crypto_bigint_helpers::mul::monty_mul(
-            x.0.inner(),
-            y.0.inner(),
-            self.params.modulus().as_ref(),
-        )
-        .into()
+        helpers::mul::monty_mul(x.0.inner(), y.0.inner(), self.params.modulus().as_ref()).into()
     }
 
     fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
-        crypto_bigint_helpers::pow::pow_bounded_exp(
+        helpers::pow::pow_bounded_exp(
             x.0.inner(),
             y.inner().as_limbs(),
             y.inner().bits_precision(),
@@ -177,7 +175,7 @@ impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
     }
 
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
-        crypto_bigint_helpers::pow::pow_u32(
+        helpers::pow::pow_u32(
             x.0.inner(),
             y,
             *self.params.one(),
@@ -270,12 +268,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> ProjectElementDynamic<Uint<LIMBS2>
         };
 
         // Convert into the Montgomery domain
-        crypto_bigint_helpers::mul::monty_mul(
-            &value,
-            self.params.r2(),
-            self.params.modulus().as_ref(),
-        )
-        .into()
+        helpers::mul::monty_mul(&value, self.params.r2(), self.params.modulus().as_ref()).into()
     }
 }
 
@@ -314,7 +307,7 @@ impl<const LIMBS: usize> LiftElementDynamic<<Self as WithAssociatedInteger>::Int
     #[inline(always)]
     fn lift(&self, value: &Self::Element) -> Self::Integer {
         let mut out = crypto_bigint::Uint::<LIMBS>::ZERO;
-        crypto_bigint_helpers::monty_retrieve_inner(
+        helpers::monty_retrieve_inner(
             value.0.inner().as_limbs(),
             out.as_mut_limbs(),
             self.params.modulus().as_ref().as_limbs(),
@@ -330,7 +323,8 @@ impl<const LIMBS: usize> LiftElementDynamic<<Self as WithAssociatedInteger>::Int
 // Predefined fields of various sizes for convenience
 //
 
-pub type F64 = MontyField<{ crypto_bigint::U64::LIMBS }>;
+use helpers::WORD_FACTOR;
+pub type F64 = MontyField<{ WORD_FACTOR }>;
 pub type F128 = MontyField<{ 2 * WORD_FACTOR }>;
 pub type F192 = MontyField<{ 3 * WORD_FACTOR }>;
 pub type F256 = MontyField<{ 4 * WORD_FACTOR }>;

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -2,14 +2,14 @@ use super::*;
 use crate::{IntRing, Wrapper, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use crypto_bigint::{
-    BitOps, NonZero, Odd, One,
+    BitOps, Limb, NonZero, Odd, Word,
     modular::{FixedMontyForm, FixedMontyParams},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)]
 pub struct MontyField<const LIMBS: usize> {
     pub params: FixedMontyParams<LIMBS>,
+    pub modulus_minus_one_div_two: Uint<LIMBS>,
 }
 
 impl<const LIMBS: usize> MontyField<LIMBS> {
@@ -17,18 +17,23 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
 
     /// Creates a new [`MontyField`] from [`FixedMontyParams`].
     #[inline(always)]
+    #[allow(clippy::arithmetic_side_effects)] // False alert
     pub const fn wrap(params: FixedMontyParams<LIMBS>) -> Self {
-        Self { params }
+        let modulus = params.modulus().get_copy();
+        let two = crypto_bigint::Uint::<LIMBS>::from_u8(2_u8)
+            .to_nz()
+            .to_inner_unchecked();
+        let (tmp, _) = modulus.borrowing_sub(&crypto_bigint::Uint::ONE, Limb(0_u8 as Word));
+        let modulus_minus_one_div_two = Uint::new(tmp.div_exact(&two).to_inner_unchecked());
+        Self {
+            params,
+            modulus_minus_one_div_two,
+        }
     }
 
     /// Unwrap the [`FixedMontyForm`] into a field config and a field element.
     pub const fn unwrap_monty(el: FixedMontyForm<LIMBS>) -> (Self, Uint<LIMBS>) {
-        (
-            Self {
-                params: *el.params(),
-            },
-            Uint::new(el.to_montgomery()),
-        )
+        (Self::wrap(*el.params()), Uint::new(el.to_montgomery()))
     }
 
     /// Reassemble the `crypto-bigint`'s [`FixedMontyForm`] from a raw
@@ -274,27 +279,22 @@ impl<const LIMBS: usize, const LIMBS2: usize> ProjectElement<Uint<LIMBS2>> for M
 // Field stuff
 //
 
-impl<const LIMBS: usize> FieldConfig for MontyField<LIMBS> {
+impl<const LIMBS: usize> BaseFieldConfig for MontyField<LIMBS> {
     fn new(modulus: &Self::Integer) -> Result<Self, FieldError> {
         let Some(modulus) = Odd::new(*modulus.inner()).into_option() else {
             return Err(FieldError::InvalidModulus);
         };
-        Ok(Self {
-            params: FixedMontyParams::new(modulus),
-        })
+        Ok(Self::wrap(FixedMontyParams::new(modulus)))
     }
 
+    #[inline(always)]
     fn modulus(&self) -> Self::Integer {
         Uint::new(self.params.modulus().get())
     }
 
-    #[allow(clippy::arithmetic_side_effects)] // False alert
+    #[inline(always)]
     fn modulus_minus_one_div_two(&self) -> Self::Integer {
-        let value = self.params.modulus().get();
-        Uint::new(
-            (value - crypto_bigint::Uint::one())
-                / NonZero::new(crypto_bigint::Uint::<LIMBS>::from(2_u8)).unwrap(),
-        )
+        self.modulus_minus_one_div_two
     }
 }
 
@@ -354,7 +354,8 @@ pub type F32768 = MontyField<{ 512 * WORD_FACTOR }>;
 #[allow(
     clippy::arithmetic_side_effects,
     clippy::cast_lossless,
-    clippy::redundant_clone
+    clippy::redundant_clone,
+    clippy::clone_on_copy
 )]
 #[cfg(test)]
 mod tests {
@@ -369,7 +370,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
-        ensure_type_implements_trait!(F, FieldConfig);
+        ensure_type_implements_trait!(F, BaseFieldConfig);
     }
 
     //
@@ -455,7 +456,7 @@ mod tests {
     fn basic_operations_overflow() {
         let f = make_f();
 
-        let mod_minus_one = Uint::new(f.params.modulus().get() - crypto_bigint::Uint::one());
+        let mod_minus_one = Uint::new(f.params.modulus().get() - crypto_bigint::Uint::ONE);
         let mod_minus_one = f.project(&mod_minus_one);
 
         // Negation
@@ -716,7 +717,7 @@ mod tests {
     fn conversions() {
         let f = make_f();
 
-        // Test EncodeElement for Uint
+        // Test ProjectElement for Uint
         let u = Uint::<LIMBS>::from(123_u64);
         let a = f.project(&u);
         assert_eq!(a, f.project(&123_u64));
@@ -881,7 +882,7 @@ mod tests {
             Uint::new(
                 (crypto_bigint::Uint::<LIMBS>::from_be_hex(
                     "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
-                ) - crypto_bigint::Uint::one())
+                ) - crypto_bigint::Uint::ONE)
                     / NonZero::new(crypto_bigint::Uint::<LIMBS>::from(2u64)).unwrap()
             )
         );

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -862,6 +862,39 @@ mod tests {
         );
     }
 
+    /// Regression test: the final AMM value of the exponentiation can land in
+    /// `[modulus, 2*modulus)`, where exactly one final conditional subtraction
+    /// is needed. `almost_montgomery_reduce` used to apply a stale comparison
+    /// to both subtractions, subtracting the modulus twice and wrapping.
+    #[test]
+    fn pow_amm_final_reduction() {
+        type F = F64;
+
+        // Using a 64-bit prime
+        let f = F::new(&Uint::from(10064419296686275259_u64)).unwrap();
+
+        // Small cases with hand-checkable results
+        for (base, exp, result) in [(2_u64, 8_u32, 256_u64), (2, 9, 512), (3, 5, 243)] {
+            assert_eq!(
+                f.pow_u32(&f.project(&base), exp),
+                f.project(&result),
+                "{base}^{exp} != {result}"
+            );
+        }
+
+        // Larger cases, verified against the library
+        for (base, exp) in [(12345_u64, 67_u32), (2, 64), (123456789, u32::MAX)] {
+            let x = f.project(&base);
+            let expected = FixedMontyForm::from_montgomery(*x.0.inner(), &f.params)
+                .pow(&crypto_bigint::Uint::<1>::from(exp));
+            assert_eq!(
+                f.pow_u32(&x, exp).0.inner(),
+                expected.as_montgomery(),
+                "{base}^{exp} diverges from FixedMontyForm::pow"
+            );
+        }
+    }
+
     #[test]
     fn prime_field_methods() {
         let f = make_f();

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -131,6 +131,17 @@ impl<const LIMBS: usize> FieldConfigOps for MontyField<LIMBS> {
         .into()
     }
 
+    fn pow(&self, x: &Self::Element, y: &Self::Integer) -> Self::Element {
+        crypto_bigint_helpers::pow::pow(
+            x.0.inner(),
+            y.inner().as_limbs(),
+            *self.params.one(),
+            self.params.modulus().as_ref(),
+            self.params.mod_neg_inv(),
+        )
+        .into()
+    }
+
     fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
         crypto_bigint_helpers::pow::pow_u32(
             x.0.inner(),
@@ -577,35 +588,45 @@ mod tests {
     fn pow_operation() {
         let f = make_f();
 
+        // Check both `pow` flavors: a `u32` exponent and the same exponent
+        // as a `Self::Integer`.
+        macro_rules! assert_pow {
+            ($base:expr, $exp:expr, $expected:expr) => {{
+                let exp: u32 = $exp;
+                assert_eq!(f.pow_u32(&$base, exp), $expected);
+                assert_eq!(f.pow(&$base, &Uint::from(exp)), $expected);
+            }};
+        }
+
         // Test basic exponentiation
         let base = f.project(&2);
 
         // 2^0 = 1
-        assert_eq!(f.pow_u32(&base, 0), f.one());
+        assert_pow!(base, 0, f.one());
 
         // 2^1 = 2
-        assert_eq!(f.pow_u32(&base, 1), base);
+        assert_pow!(base, 1, base);
 
         // 2^3 = 8
-        assert_eq!(f.pow_u32(&base, 3), f.project(&8));
+        assert_pow!(base, 3, f.project(&8));
 
         // 2^10 = 1024
-        assert_eq!(f.pow_u32(&base, 10), f.project(&1024));
+        assert_pow!(base, 10, f.project(&1024));
 
         // Test with different base
         let base = f.project(&3);
 
         // 3^4 = 81
-        assert_eq!(f.pow_u32(&base, 4), f.project(&81));
+        assert_pow!(base, 4, f.project(&81));
 
         // Test with base 1
         let base = f.one();
-        assert_eq!(f.pow_u32(&base, 1000), f.one());
+        assert_pow!(base, 1000, f.one());
 
         // Test with base 0
         let base = f.zero();
-        assert_eq!(f.pow_u32(&base, 0), f.one()); // 0^0 = 1 by convention
-        assert_eq!(f.pow_u32(&base, 10), f.zero()); // 0^n = 0 for n > 0
+        assert_pow!(base, 0, f.one()); // 0^0 = 1 by convention
+        assert_pow!(base, 10, f.zero()); // 0^n = 0 for n > 0
     }
 
     #[test]
@@ -792,7 +813,23 @@ mod tests {
                 expected.as_montgomery(),
                 "{base}^{exp} diverges from FixedMontyForm::pow"
             );
+            assert_eq!(
+                f.pow(&x, &Uint::from(exp)).0.inner(),
+                expected.as_montgomery(),
+                "{base}^{exp} (integer exponent) diverges from FixedMontyForm::pow"
+            );
         }
+
+        // An exponent wider than u32 (integer-exponent `pow` only)
+        let x = f.project(&123456789_u64);
+        let exp = u128::MAX;
+        let expected = FixedMontyForm::from_montgomery(*x.0.inner(), &f.params)
+            .pow(&crypto_bigint::Uint::<LIMBS>::from(exp));
+        assert_eq!(
+            f.pow(&x, &Uint::from(exp)).0.inner(),
+            expected.as_montgomery(),
+            "u128::MAX exponent diverges from FixedMontyForm::pow"
+        );
     }
 
     #[test]

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -3,7 +3,10 @@ use crate::{
     IntSemiring, IntSemiringConfig, LiftElementWithConfig, Wrapper, boolean::Boolean,
     crypto_bigint_int::Int, crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
-use core::fmt::{Display, Formatter, Result as FmtResult};
+use core::{
+    cmp::Ordering,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 use crypto_bigint::{
     BitOps, Limb, NonZero, Odd, Word,
     modular::{FixedMontyForm, FixedMontyParams},
@@ -50,9 +53,23 @@ impl<const LIMBS: usize> MontyField<LIMBS> {
 
 /// A wrapper around [`Uint`] to prevent accidentally calling math operations
 /// on it.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct MontyFieldElement<const LIMBS: usize>(pub Uint<LIMBS>);
+
+/// Compares Montgomery form, not values.
+impl<const LIMBS: usize> PartialOrd for MontyFieldElement<LIMBS> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Compares Montgomery form, not values.
+impl<const LIMBS: usize> Ord for MontyFieldElement<LIMBS> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
 
 impl<const LIMBS: usize> From<Uint<LIMBS>> for MontyFieldElement<LIMBS> {
     #[inline(always)]

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ConstBaseField, ConstSemiring, FixedField, IntSemiring, LiftToIntegerStatic, Ring, Semiring,
+    ConstBaseField, ConstSemiring, FixedField, IntSemiring, LiftElementStatic, Ring, Semiring,
     WithAssociatedInteger, Wrapper, boolean::Boolean,
 };
 use core::{
@@ -440,9 +440,9 @@ impl WithAssociatedInteger for F2 {
     type Integer = u8;
 }
 
-impl LiftToIntegerStatic for F2 {
+impl LiftElementStatic<<Self as WithAssociatedInteger>::Integer> for F2 {
     #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
+    fn lift(&self) -> <Self as WithAssociatedInteger>::Integer {
         u8::from(self.0)
     }
 }
@@ -479,7 +479,7 @@ impl zeroize::DefaultIsZeroes for F2 {}
 mod tests {
     use super::*;
     use crate::{
-        BaseFieldConfig, ConstIntRing, FieldConfigOps, FixedBaseField, FixedFieldConfig,
+        BaseFieldConfig, ConstIntRing, FieldConfig, FixedBaseField, FixedFieldConfig,
         ensure_type_implements_trait,
     };
     use alloc::format;
@@ -513,7 +513,7 @@ mod tests {
 
         // Lifting to integer and projecting back yields the original element.
         for x in [V0, V1] {
-            assert_eq!(F2::from(x.lift_to_integer()), x);
+            assert_eq!(F2::from(x.lift()), x);
         }
     }
 

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ConstBaseField, ConstRing, ConstSemiring, FixedField, FixedRing, IntRing, IntSemiring,
-    LiftToIntegerStatic, Ring, Semiring, WithAssociatedInteger, Wrapper, boolean::Boolean,
+    ConstBaseField, ConstSemiring, FixedField, IntSemiring, LiftToIntegerStatic, Ring, Semiring,
+    WithAssociatedInteger, Wrapper, boolean::Boolean,
 };
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -1,6 +1,5 @@
 use crate::{
-    ConstBaseField, ConstSemiring, FixedField, IntSemiring, LiftElementStatic, Ring, Semiring,
-    WithAssociatedInteger, Wrapper, boolean::Boolean,
+    ConstBaseField, IntSemiring, LiftElement, WithAssociatedInteger, Wrapper, boolean::Boolean,
 };
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -11,8 +10,8 @@ use core::{
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
 use num_traits::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, Inv, One, Pow,
-    Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, Inv,
+    One, Pow, Zero,
 };
 
 #[cfg(feature = "rand")]
@@ -408,11 +407,16 @@ impl Wrapper for F2 {
 // Semiring, Ring and Field
 //
 
-impl Semiring for F2 {}
+impl Bounded for F2 {
+    #[inline(always)]
+    fn min_value() -> Self {
+        Self::ZERO
+    }
 
-impl ConstSemiring for F2 {
-    const MAX: Self = Self::ONE;
-    const MIN: Self = Self::ZERO;
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::ONE
+    }
 }
 
 impl IntSemiring for F2 {
@@ -427,10 +431,6 @@ impl IntSemiring for F2 {
     }
 }
 
-impl Ring for F2 {}
-
-impl FixedField for F2 {}
-
 impl ConstBaseField for F2 {
     const MODULUS: Self::Integer = 2;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = 0;
@@ -440,7 +440,7 @@ impl WithAssociatedInteger for F2 {
     type Integer = u8;
 }
 
-impl LiftElementStatic<<Self as WithAssociatedInteger>::Integer> for F2 {
+impl LiftElement<<Self as WithAssociatedInteger>::Integer> for F2 {
     #[inline(always)]
     fn lift(&self) -> <Self as WithAssociatedInteger>::Integer {
         u8::from(self.0)
@@ -479,7 +479,7 @@ impl zeroize::DefaultIsZeroes for F2 {}
 mod tests {
     use super::*;
     use crate::{
-        BaseFieldConfig, ConstIntRing, FieldConfig, FixedBaseField, FixedFieldConfig,
+        BaseField, BaseFieldConfig, ConstField, FieldConfig, FixedConfig, SemiringConfig,
         ensure_type_implements_trait,
     };
     use alloc::format;
@@ -490,9 +490,10 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
-        ensure_type_implements_trait!(F2, ConstIntRing);
-        ensure_type_implements_trait!(F2, FixedBaseField);
+        ensure_type_implements_trait!(F2, ConstField);
+        ensure_type_implements_trait!(F2, BaseField);
         ensure_type_implements_trait!(F2, ConstBaseField);
+        ensure_type_implements_trait!(FixedConfig<F2>, BaseFieldConfig);
     }
 
     #[test]
@@ -679,7 +680,7 @@ mod tests {
 
     #[test]
     fn config_pow() {
-        let cfg = FixedFieldConfig::<F2>::default();
+        let cfg = FixedConfig::<F2>::default();
 
         assert_eq!(cfg.pow_u32(&V0, 0), V1); // 0^0 = 1 by convention
         assert_eq!(cfg.pow_u32(&V0, 2), V0);
@@ -770,7 +771,7 @@ mod tests {
         assert_eq!(F2::modulus(), 2_u8);
         assert_eq!(F2::modulus_minus_one_div_two(), 0_u8);
 
-        type Cfg = FixedFieldConfig<F2>;
+        type Cfg = FixedConfig<F2>;
         assert!(Cfg::new(&2_u8).is_ok());
         assert!(Cfg::new(&0_u8).is_err());
         assert!(Cfg::new(&3_u8).is_err());

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -459,6 +459,30 @@ impl Distribution<F2> for StandardUniform {
 }
 
 //
+// Serialization and Deserialization
+//
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for F2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        bool::deserialize(deserializer).map(Self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for F2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+//
 // Zeroize
 //
 

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -479,7 +479,7 @@ impl zeroize::DefaultIsZeroes for F2 {}
 mod tests {
     use super::*;
     use crate::{
-        ConstIntRing, FieldConfig, FieldConfigOps, FixedBaseField, FixedFieldConfig,
+        BaseFieldConfig, ConstIntRing, FieldConfigOps, FixedBaseField, FixedFieldConfig,
         ensure_type_implements_trait,
     };
     use alloc::format;

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -1,4 +1,7 @@
-use crate::{ConstPrimeField, ConstSemiring, Field, Ring, Semiring, boolean::Boolean};
+use crate::{
+    ConstBaseField, ConstRing, ConstSemiring, FixedField, FixedRing, IntRing, IntSemiring,
+    LiftToIntegerStatic, Ring, Semiring, WithAssociatedInteger, boolean::Boolean,
+};
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::Hash,
@@ -378,11 +381,22 @@ impl ConstSemiring for F2 {
     const MIN: Self = Self::ZERO;
 }
 
+impl IntSemiring for F2 {
+    #[inline(always)]
+    fn is_odd(&self) -> bool {
+        !self.is_zero()
+    }
+
+    #[inline(always)]
+    fn is_even(&self) -> bool {
+        self.is_zero()
+    }
+}
+
 impl Ring for F2 {}
 
-impl Field for F2 {
+impl FixedField for F2 {
     type Inner = bool;
-    type Integer = u8;
 
     #[inline(always)]
     fn inner(&self) -> &Self::Inner {
@@ -400,18 +414,24 @@ impl Field for F2 {
     }
 
     #[inline(always)]
-    fn lift_to_integer(&self) -> Self::Integer {
-        u8::from(self.0)
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
     }
 }
 
-impl ConstPrimeField for F2 {
+impl ConstBaseField for F2 {
     const MODULUS: Self::Integer = 2;
     const MODULUS_MINUS_ONE_DIV_TWO: Self::Integer = 0;
+}
 
+impl WithAssociatedInteger for F2 {
+    type Integer = u8;
+}
+
+impl LiftToIntegerStatic for F2 {
     #[inline(always)]
-    fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(inner)
+    fn lift_to_integer(&self) -> Self::Integer {
+        u8::from(self.0)
     }
 }
 
@@ -447,7 +467,7 @@ impl zeroize::DefaultIsZeroes for F2 {}
 mod tests {
     use super::*;
     use crate::{
-        ConstPrimeField, FromPrimitiveWithConfig, PrimeField, ensure_type_implements_trait,
+        ConstIntRing, FieldConfig, FixedBaseField, FixedFieldConfig, ensure_type_implements_trait,
     };
     use alloc::format;
     use num_traits::{One, Zero};
@@ -456,9 +476,10 @@ mod tests {
     const V1: F2 = F2::ONE;
 
     #[test]
-    fn ensure_blanket_traits() {
-        // NB: this ensures `PrimeField` implementation too!
-        ensure_type_implements_trait!(F2, FromPrimitiveWithConfig);
+    fn ensure_traits() {
+        ensure_type_implements_trait!(F2, ConstIntRing);
+        ensure_type_implements_trait!(F2, FixedBaseField);
+        ensure_type_implements_trait!(F2, ConstBaseField);
     }
 
     #[test]
@@ -472,12 +493,10 @@ mod tests {
     #[test]
     fn zero_one_basics() {
         assert!(V0.is_zero());
-        assert!(PrimeField::is_zero(&V0));
         assert!(!V1.is_zero());
-        assert!(!PrimeField::is_zero(&V1));
         assert_ne!(V0, V1);
 
-        assert_eq!(F2::from(F2::modulus(&())), V0);
+        assert_eq!(F2::from(F2::modulus()), V0);
 
         // Lifting to integer and projecting back yields the original element.
         for x in [V0, V1] {
@@ -704,8 +723,8 @@ mod tests {
 
     #[test]
     fn const_prime_field() {
-        assert_eq!(<F2 as ConstPrimeField>::MODULUS, 2_u8);
-        assert_eq!(<F2 as ConstPrimeField>::MODULUS_MINUS_ONE_DIV_TWO, 0_u8);
+        assert_eq!(<F2 as ConstBaseField>::MODULUS, 2_u8);
+        assert_eq!(<F2 as ConstBaseField>::MODULUS_MINUS_ONE_DIV_TWO, 0_u8);
 
         assert_eq!(F2::new(true), V1);
         assert_eq!(F2::new(false), V0);
@@ -715,11 +734,13 @@ mod tests {
 
     #[test]
     fn prime_field_methods() {
-        assert_eq!(F2::modulus(&()), 2_u8);
-        assert_eq!(F2::modulus_minus_one_div_two(&()), 0_u8);
-        assert_eq!(F2::make_cfg(&2_u8), Ok(()));
-        assert!(F2::make_cfg(&0_u8).is_err());
-        assert!(F2::make_cfg(&3_u8).is_err());
+        assert_eq!(F2::modulus(), 2_u8);
+        assert_eq!(F2::modulus_minus_one_div_two(), 0_u8);
+
+        type Cfg = FixedFieldConfig<F2>;
+        assert!(Cfg::new(&2_u8).is_ok());
+        assert!(Cfg::new(&0_u8).is_err());
+        assert!(Cfg::new(&3_u8).is_err());
     }
 
     #[test]
@@ -776,13 +797,13 @@ mod tests {
         assert_eq!(V1.into_inner(), true);
         assert_eq!(V0.into_inner(), false);
 
-        // Field::inner
-        assert_eq!(*Field::inner(&V1), true);
-        assert_eq!(*Field::inner(&V0), false);
+        // FixedFieldBase::inner
+        assert_eq!(*FixedField::inner(&V1), true);
+        assert_eq!(*FixedField::inner(&V0), false);
 
-        // Field::inner_mut
+        // FixedFieldBase::inner_mut
         let mut x = V0;
-        *Field::inner_mut(&mut x) = true;
+        *FixedField::inner_mut(&mut x) = true;
         assert_eq!(x, V1);
     }
 }

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -1,6 +1,6 @@
 use crate::{
     ConstBaseField, ConstRing, ConstSemiring, FixedField, FixedRing, IntRing, IntSemiring,
-    LiftToIntegerStatic, Ring, Semiring, WithAssociatedInteger, boolean::Boolean,
+    LiftToIntegerStatic, Ring, Semiring, WithAssociatedInteger, Wrapper, boolean::Boolean,
 };
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -25,25 +25,13 @@ use rand::{distr::StandardUniform, prelude::*};
 #[infallible_checked_unary_op((CheckedNeg, neg))]
 #[infallible_checked_binary_op((CheckedAdd, add), (CheckedSub, sub), (CheckedMul, mul))]
 #[repr(transparent)]
-pub struct F2(bool);
+pub struct F2(pub bool);
 
 impl F2 {
     /// Creates a new F2 element from a bool value.
     #[inline(always)]
     pub const fn new(value: bool) -> Self {
         Self(value)
-    }
-
-    /// Get the inner bool value.
-    #[inline(always)]
-    pub const fn inner(&self) -> &bool {
-        &self.0
-    }
-
-    /// Convert to the inner bool value.
-    #[inline(always)]
-    pub const fn into_inner(self) -> bool {
-        self.0
     }
 }
 
@@ -389,6 +377,34 @@ impl_from_unsigned!(u8, u16, u32, u64, u128);
 impl_from_signed!(i8, i16, i32, i64, i128);
 
 //
+// Wrapper
+//
+
+impl Wrapper for F2 {
+    type Inner = bool;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
+    }
+}
+
+//
 // Semiring, Ring and Field
 //
 
@@ -413,29 +429,7 @@ impl IntSemiring for F2 {
 
 impl Ring for F2 {}
 
-impl FixedField for F2 {
-    type Inner = bool;
-
-    #[inline(always)]
-    fn inner(&self) -> &Self::Inner {
-        &self.0
-    }
-
-    #[inline(always)]
-    fn inner_mut(&mut self) -> &mut Self::Inner {
-        &mut self.0
-    }
-
-    #[inline(always)]
-    fn into_inner(self) -> Self::Inner {
-        self.0
-    }
-
-    #[inline(always)]
-    fn new_unchecked(inner: Self::Inner) -> Self {
-        Self(inner)
-    }
-}
+impl FixedField for F2 {}
 
 impl ConstBaseField for F2 {
     const MODULUS: Self::Integer = 2;
@@ -836,13 +830,13 @@ mod tests {
         assert_eq!(V1.into_inner(), true);
         assert_eq!(V0.into_inner(), false);
 
-        // FixedFieldBase::inner
-        assert_eq!(*FixedField::inner(&V1), true);
-        assert_eq!(*FixedField::inner(&V0), false);
+        // Wrapper::inner
+        assert_eq!(*Wrapper::inner(&V1), true);
+        assert_eq!(*Wrapper::inner(&V0), false);
 
-        // FixedFieldBase::inner_mut
+        // Wrapper::inner_mut
         let mut x = V0;
-        *FixedField::inner_mut(&mut x) = true;
+        *Wrapper::inner_mut(&mut x) = true;
         assert_eq!(x, V1);
     }
 }

--- a/src/field/f2.rs
+++ b/src/field/f2.rs
@@ -189,6 +189,24 @@ impl Pow<u32> for F2 {
     }
 }
 
+impl Pow<u8> for F2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, rhs: u8) -> Self::Output {
+        self.pow(u32::from(rhs))
+    }
+}
+
+impl Pow<&u8> for F2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, rhs: &u8) -> Self::Output {
+        self.pow(u32::from(*rhs))
+    }
+}
+
 impl Inv for F2 {
     type Output = Option<Self>;
 
@@ -467,7 +485,8 @@ impl zeroize::DefaultIsZeroes for F2 {}
 mod tests {
     use super::*;
     use crate::{
-        ConstIntRing, FieldConfig, FixedBaseField, FixedFieldConfig, ensure_type_implements_trait,
+        ConstIntRing, FieldConfig, FieldConfigOps, FixedBaseField, FixedFieldConfig,
+        ensure_type_implements_trait,
     };
     use alloc::format;
     use num_traits::{One, Zero};
@@ -644,18 +663,38 @@ mod tests {
     #[test]
     fn pow_operation() {
         // 0^0 = 1 by convention
-        assert_eq!(V0.pow(0), V1);
+        assert_eq!(V0.pow(0_u32), V1);
 
         // 0^n = 0 for n > 0
-        assert_eq!(V0.pow(1), V0);
-        assert_eq!(V0.pow(2), V0);
-        assert_eq!(V0.pow(100), V0);
+        assert_eq!(V0.pow(1_u32), V0);
+        assert_eq!(V0.pow(2_u32), V0);
+        assert_eq!(V0.pow(100_u32), V0);
 
         // 1^n = 1 for all n
-        assert_eq!(V1.pow(0), V1);
-        assert_eq!(V1.pow(1), V1);
-        assert_eq!(V1.pow(2), V1);
-        assert_eq!(V1.pow(100), V1);
+        assert_eq!(V1.pow(0_u32), V1);
+        assert_eq!(V1.pow(1_u32), V1);
+        assert_eq!(V1.pow(2_u32), V1);
+        assert_eq!(V1.pow(100_u32), V1);
+
+        // Same checks via `u8` (`Self::Integer`) exponents
+        assert_eq!(V0.pow(0_u8), V1);
+        assert_eq!(V0.pow(&2_u8), V0);
+        assert_eq!(V1.pow(0_u8), V1);
+        assert_eq!(V1.pow(&100_u8), V1);
+    }
+
+    #[test]
+    fn config_pow() {
+        let cfg = FixedFieldConfig::<F2>::default();
+
+        assert_eq!(cfg.pow_u32(&V0, 0), V1); // 0^0 = 1 by convention
+        assert_eq!(cfg.pow_u32(&V0, 2), V0);
+        assert_eq!(cfg.pow_u32(&V1, 100), V1);
+
+        assert_eq!(cfg.pow(&V0, &0_u8), V1); // 0^0 = 1 by convention
+        assert_eq!(cfg.pow(&V0, &1_u8), V0);
+        assert_eq!(cfg.pow(&V1, &0_u8), V1);
+        assert_eq!(cfg.pow(&V1, &1_u8), V1);
     }
 
     #[test]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,9 @@
 //! Contains helper utility functions and macros not visible to the outside
 //! world.
 
+#[cfg(feature = "crypto_bigint")]
+pub(crate) mod crypto_bigint;
+
 /// Implement exponentiation using repeated squaring
 #[macro_export]
 macro_rules! pow_via_repeated_squaring {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,8 +4,19 @@
 #[cfg(feature = "crypto_bigint")]
 pub(crate) mod crypto_bigint;
 
+/// Define an empty trait with the given supertraits, and make a blanket
+/// implementation for it.
+macro_rules! define_blanket_trait {
+    ($(#[$attr:meta])* $vis:vis trait $trait_name:ident: $($bound:tt)+) => {
+        $(#[$attr])*
+        $vis trait $trait_name: $($bound)+ {}
+
+        impl<T> $trait_name for T where T: $($bound)* {}
+    };
+}
+pub(crate) use define_blanket_trait;
+
 /// Implement exponentiation using repeated squaring
-#[macro_export]
 macro_rules! pow_via_repeated_squaring {
     ($self:expr, $rhs:expr, $one:expr) => {{
         if $rhs == 0 {
@@ -31,6 +42,7 @@ macro_rules! pow_via_repeated_squaring {
         result
     }};
 }
+pub(crate) use pow_via_repeated_squaring;
 
 /// Will fail compilation if trait is not implemented for the type.
 #[cfg(test)]
@@ -42,7 +54,6 @@ macro_rules! ensure_type_implements_trait {
     }};
 }
 
-#[macro_export]
 macro_rules! delegate_to_ref_binary {
     ($(#[$attr:meta])* $op:ident) => {
         delegate_to_ref_binary!($(#[$attr])* $op(&Self::Element));
@@ -56,3 +67,4 @@ macro_rules! delegate_to_ref_binary {
         }
     };
 }
+pub(crate) use delegate_to_ref_binary;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -41,3 +41,18 @@ macro_rules! ensure_type_implements_trait {
         _assert_impl::<$type_name>();
     }};
 }
+
+#[macro_export]
+macro_rules! delegate_to_ref_binary {
+    ($(#[$attr:meta])* $op:ident) => {
+        delegate_to_ref_binary!($(#[$attr])* $op(&Self::Element));
+    };
+    ($(#[$attr:meta])* $op:ident($rhs_type:ty)) => {
+        paste! {
+            $(#[$attr])*
+            fn [<$op _assign>](&self, x: &mut Self::Element, y: $rhs_type) {
+                *x = self.$op(x, y);
+            }
+        }
+    };
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -33,7 +33,7 @@ macro_rules! pow_via_repeated_squaring {
 #[cfg(test)]
 #[macro_export]
 macro_rules! ensure_type_implements_trait {
-    ($type_name:ty, $trait_name:ident) => {{
+    ($type_name:ty, $trait_name:path) => {{
         fn _assert_impl<T: $trait_name>() {}
         _assert_impl::<$type_name>();
     }};

--- a/src/helpers/crypto_bigint.rs
+++ b/src/helpers/crypto_bigint.rs
@@ -434,9 +434,8 @@ pub mod pow {
     }
 
     fn almost_montgomery_reduce(z: &mut UintRef, modulus: &UintRef) {
-        let choice = UintRef::cmp_vartime(z, modulus).is_ge();
-        conditional_borrowing_sub_assign(z, modulus, choice);
-        conditional_borrowing_sub_assign(z, modulus, choice);
+        conditional_borrowing_sub_assign(z, modulus, UintRef::cmp_vartime(z, modulus).is_ge());
+        conditional_borrowing_sub_assign(z, modulus, UintRef::cmp_vartime(z, modulus).is_ge());
     }
 
     fn conditional_borrowing_sub_assign(lhs: &mut UintRef, rhs: &UintRef, choice: bool) -> bool {

--- a/src/helpers/crypto_bigint.rs
+++ b/src/helpers/crypto_bigint.rs
@@ -1,6 +1,12 @@
 #![allow(clippy::arithmetic_side_effects, clippy::needless_range_loop)]
-
 use crypto_bigint::Limb;
+
+/// How many words/limbs there are per 64 bits.
+#[cfg(target_pointer_width = "64")]
+pub const WORD_FACTOR: usize = 1;
+/// How many words/limbs there are per 64 bits.
+#[cfg(target_pointer_width = "32")]
+pub const WORD_FACTOR: usize = 2;
 
 /// Copy-paste from `crypto-bigint`
 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub trait Wrapper {
 pub trait SetElement: Debug + Clone + Eq + Send + Sync + 'static {}
 impl<T> SetElement for T where T: Debug + Clone + Eq + Send + Sync + 'static {}
 
-pub trait SetConfig {
+pub trait SetConfig: Debug + Clone + Eq + Send + Sync {
     type Element: SetElement;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use matrix::*;
 pub use ring::*;
 pub use semiring::*;
 
+use crate::helpers::define_blanket_trait;
 use core::{fmt::Debug, marker::PhantomData};
 
 /// A thin wrapper around some underlying representation.
@@ -55,10 +56,11 @@ pub trait Wrapper {
     fn new_unchecked(inner: Self::Inner) -> Self;
 }
 
-/// Base type we demand of all of our set elements - values that would be passed
-/// around.
-pub trait SetElement: Debug + Clone + Eq + Send + Sync + 'static {}
-impl<T> SetElement for T where T: Debug + Clone + Eq + Send + Sync + 'static {}
+define_blanket_trait! {
+    /// Base type we demand of all of our set elements - values that would be passed
+    /// around.
+    pub trait SetElement: Debug + Clone + Eq + Send + Sync + 'static
+}
 
 pub trait SetConfig: Debug + Clone + Eq + Send + Sync {
     type Element: SetElement;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,12 @@ pub trait ParseStrConfig: SetConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FixedConfig<T: SetElement>(PhantomData<T>);
 
+impl<T: SetElement> FixedConfig<T> {
+    pub const fn const_default() -> Self {
+        FixedConfig(PhantomData)
+    }
+}
+
 impl<T: SetElement> SetConfig for FixedConfig<T> {
     type Element = T;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,27 @@ pub use field::*;
 pub use matrix::*;
 pub use ring::*;
 pub use semiring::*;
+
+use core::fmt::Debug;
+
+/// A thin wrapper around some underlying representation.
+pub trait Wrapper {
+    /// Type of the underlying representation of this structure.
+    type Inner: Debug + Eq + Clone + Sync + Send;
+
+    /// Get a reference to the wrapped value.
+    fn inner(&self) -> &Self::Inner;
+
+    /// Get a mutable reference to the wrapped value.
+    fn inner_mut(&mut self) -> &mut Self::Inner;
+
+    /// Get the wrapped value, consuming self.
+    fn into_inner(self) -> Self::Inner;
+
+    /// Creates a new instance of this structure from a representation
+    /// known to be valid - should consume exactly the value returned by
+    /// `inner()`. Ideally, this should not check the validity of the
+    /// element, but it's acceptable to perform a check if it can't be
+    /// avoided.
+    fn new_unchecked(inner: Self::Inner) -> Self;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,22 @@
+//! This crate defines an algebraic hierarchy of **sets**, **semirings**,
+//! **rings** and **fields**. Supports both static and dynamic structures (via
+//! the general `*Config` traits: [`SetConfig`], [`SemiringConfig`],
+//! [`RingConfig`] and [`FieldConfig`]).
+//!
+//! - [`Semiring`], [`Ring`] and [`Field`] (along with their `Const*` variants)
+//!   are structures where each element is self-sufficient. Instances carry
+//!   around all metadata necessary to perform operations, so they can be used
+//!   normally as e.g. `a + b`. Every `Const*` structure implements its
+//!   non-const counterpart as well. These traits have blanket implementations.
+//!
+//! - [`SemiringConfig`], [`RingConfig`] and [`FieldConfig`] are configurations
+//!   that carry the metadata needed to perform operations that the elements
+//!   themselves do not carry, e.g. a modulus only available at runtime. They're
+//!   used as `f.add(&a, &b)`.
+//!
+//! - Bridge between these and structures with self-sufficient elements is
+//!   [`FixedConfig`].
+
 #![no_std]
 extern crate alloc;
 
@@ -12,12 +31,12 @@ pub use matrix::*;
 pub use ring::*;
 pub use semiring::*;
 
-use core::fmt::Debug;
+use core::{fmt::Debug, marker::PhantomData};
 
 /// A thin wrapper around some underlying representation.
 pub trait Wrapper {
     /// Type of the underlying representation of this structure.
-    type Inner: Debug + Eq + Clone + Sync + Send;
+    type Inner: Debug + Clone + Eq + Send + Sync;
 
     /// Get a reference to the wrapped value.
     fn inner(&self) -> &Self::Inner;
@@ -34,4 +53,29 @@ pub trait Wrapper {
     /// element, but it's acceptable to perform a check if it can't be
     /// avoided.
     fn new_unchecked(inner: Self::Inner) -> Self;
+}
+
+/// Base type we demand of all of our set elements - values that would be passed
+/// around.
+pub trait SetElement: Debug + Clone + Eq + Send + Sync + 'static {}
+impl<T> SetElement for T where T: Debug + Clone + Eq + Send + Sync + 'static {}
+
+pub trait SetConfig {
+    type Element: SetElement;
+}
+
+pub trait ParseStrConfig: SetConfig {
+    fn parse_str(&self, str: &str) -> Option<Self::Element>;
+}
+
+/// Bridge between set configs and fixed sets with self-sufficient elements that
+/// delegates config operations to the set itself.
+///
+/// Use [`Default::default`] to get a usable instance.
+/// For fields, `new` checks if the modulus matches the static one.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FixedConfig<T: SetElement>(PhantomData<T>);
+
+impl<T: SetElement> SetConfig for FixedConfig<T> {
+    type Element = T;
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,3 +1,5 @@
+//! WARNING: This module has not been stabilized!
+
 use alloc::vec::Vec;
 use core::mem::{ManuallyDrop, MaybeUninit};
 

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,43 +1,34 @@
+//! This module defines **rings** - [`semirings`](crate::semiring) where every
+//! element has an additive inverse (and hence negation is defined).
+//!
+//! See the [crate-level documentation](crate) for the overall element/config
+//! structure.
+//!
+//! This module additionally defines several specialized flavors of rings for
+//! working with integers.
+
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_int;
 
 use crate::{
-    ConstIntSemiring, ConstSemiring, FixedSemiring, IntSemiring, IntSemiringWithShifts, Semiring,
+    ConstIntSemiring, ConstIntSemiringConfig, ConstSemiring, FixedConfig, IntSemiring,
+    IntSemiringConfig, IntSemiringWithDivRem, IntSemiringWithShifts, Semiring, SemiringConfig,
+    SetElement,
 };
-use core::ops::{Neg, Rem, RemAssign};
-use num_traits::{CheckedNeg, CheckedRem};
+use core::ops::Neg;
+use num_traits::{CheckedNeg, Signed};
 
-/// A ring is a semiring with subtraction, meaning it has an additive inverse
-/// for every element.
-pub trait Ring: Semiring + Neg<Output = Self> + CheckedNeg {}
+/// See [module-level documentation](crate::ring).
+pub trait Ring: SetElement + Semiring + Neg<Output = Self> + CheckedNeg {}
+impl<T> Ring for T where T: SetElement + Semiring + Neg<Output = Self> + CheckedNeg {}
 
-/// Ring whose zero and one elements can be constructed from the type alone.
-pub trait FixedRing: Ring + FixedSemiring {}
-impl<T> FixedRing for T where T: Ring + FixedSemiring {}
-
-/// Ring with a bunch of values known at compile time.
-pub trait ConstRing: FixedRing + ConstSemiring {}
-impl<T> ConstRing for T where T: FixedRing + ConstSemiring {}
+/// [`Ring`] with a bunch of values known at compile time.
+pub trait ConstRing: Ring + ConstSemiring {}
+impl<T> ConstRing for T where T: Ring + ConstSemiring {}
 
 /// Ring of integers, usually denoted as `Z`.
-pub trait IntRing: Ring + IntSemiring {
-    /// Checked absolute value. Computes `self.abs()`, returning `None` if `self
-    /// == MIN`.
-    fn checked_abs(&self) -> Option<Self>;
-
-    fn is_positive(&self) -> bool;
-
-    fn is_negative(&self) -> bool;
-}
-
-pub trait IntRingWithRem:
-    IntRing + CheckedRem + RemAssign + for<'a> Rem<&'a Self> + for<'a> RemAssign<&'a Self>
-{
-}
-impl<T> IntRingWithRem for T where
-    T: IntRing + CheckedRem + RemAssign + for<'a> Rem<&'a Self> + for<'a> RemAssign<&'a Self>
-{
-}
+pub trait IntRing: Ring + IntSemiringWithDivRem + Signed {}
+impl<T> IntRing for T where T: Ring + IntSemiringWithDivRem + Signed {}
 
 pub trait IntRingWithShifts: IntRing + IntSemiringWithShifts {}
 impl<T> IntRingWithShifts for T where T: IntRing + IntSemiringWithShifts {}
@@ -45,27 +36,86 @@ impl<T> IntRingWithShifts for T where T: IntRing + IntSemiringWithShifts {}
 pub trait ConstIntRing: IntRing + ConstIntSemiring + From<i8> {}
 impl<T> ConstIntRing for T where T: IntRing + ConstIntSemiring + From<i8> {}
 
-macro_rules! primitive_int_ring {
-    ($t:ident) => {
-        impl Ring for $t {}
-        impl IntRing for $t {
-            fn checked_abs(&self) -> Option<Self> {
-                $t::checked_abs(*self)
-            }
+/// See [module-level documentation](crate::ring).
+pub trait RingConfig: SemiringConfig {
+    /// -x
+    fn neg(&self, x: &Self::Element) -> Self::Element;
 
-            fn is_positive(&self) -> bool {
-                *self > 0
-            }
+    /// -x;
+    fn checked_neg(&self, x: &Self::Element) -> Option<Self::Element>;
 
-            fn is_negative(&self) -> bool {
-                *self < 0
-            }
-        }
-    };
+    /// x = -x;
+    fn neg_assign(&self, x: &mut Self::Element) {
+        *x = self.neg(x);
+    }
 }
 
-primitive_int_ring!(i8);
-primitive_int_ring!(i16);
-primitive_int_ring!(i32);
-primitive_int_ring!(i64);
-primitive_int_ring!(i128);
+pub trait IntRingConfig: RingConfig + IntSemiringConfig {}
+impl<R> IntRingConfig for R where R: RingConfig + IntSemiringConfig {}
+
+pub trait ConstIntRingConfig: IntRingConfig + ConstIntSemiringConfig {
+    /// |x|
+    fn abs(&self, x: &Self::Element) -> Self::Element;
+
+    /// Checked absolute value. Returns `None` if the result cannot be
+    /// represented.
+    fn checked_abs(&self, x: &Self::Element) -> Option<Self::Element>;
+
+    fn signum(&self, x: &Self::Element) -> Self::Element;
+
+    fn is_positive(&self, x: &Self::Element) -> bool;
+
+    fn is_negative(&self, x: &Self::Element) -> bool;
+}
+
+impl<R: Ring> RingConfig for FixedConfig<R> {
+    #[inline(always)]
+    fn neg(&self, x: &Self::Element) -> Self::Element {
+        x.clone().neg()
+    }
+
+    fn checked_neg(&self, x: &Self::Element) -> Option<Self::Element> {
+        x.checked_neg()
+    }
+}
+
+impl<R: ConstIntRing> ConstIntRingConfig for FixedConfig<R> {
+    fn abs(&self, x: &Self::Element) -> Self::Element {
+        x.abs()
+    }
+
+    fn checked_abs(&self, x: &Self::Element) -> Option<Self::Element> {
+        if *x == R::min_value() {
+            None
+        } else {
+            Some(x.abs())
+        }
+    }
+
+    fn signum(&self, x: &Self::Element) -> Self::Element {
+        x.signum()
+    }
+
+    fn is_positive(&self, x: &Self::Element) -> bool {
+        x.is_positive()
+    }
+
+    fn is_negative(&self, x: &Self::Element) -> bool {
+        x.is_negative()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ensure_type_implements_trait;
+
+    #[test]
+    fn ensure_traits() {
+        ensure_type_implements_trait!(i8, ConstIntRing);
+        ensure_type_implements_trait!(i128, ConstIntRing);
+
+        ensure_type_implements_trait!(FixedConfig<i8>, ConstIntRingConfig);
+        ensure_type_implements_trait!(FixedConfig<i128>, ConstIntRingConfig);
+    }
+}

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -13,28 +13,33 @@ pub mod crypto_bigint_int;
 use crate::{
     ConstIntSemiring, ConstIntSemiringConfig, ConstSemiring, FixedConfig, IntSemiring,
     IntSemiringConfig, IntSemiringWithDivRem, IntSemiringWithShifts, Semiring, SemiringConfig,
-    SetElement,
+    SetElement, helpers::define_blanket_trait,
 };
 use core::ops::Neg;
 use num_traits::{CheckedNeg, Signed};
 
-/// See [module-level documentation](crate::ring).
-pub trait Ring: SetElement + Semiring + Neg<Output = Self> + CheckedNeg {}
-impl<T> Ring for T where T: SetElement + Semiring + Neg<Output = Self> + CheckedNeg {}
+define_blanket_trait! {
+    /// See [module-level documentation](crate::ring).
+    pub trait Ring: SetElement + Semiring + Neg<Output = Self> + CheckedNeg
+}
 
-/// [`Ring`] with a bunch of values known at compile time.
-pub trait ConstRing: Ring + ConstSemiring {}
-impl<T> ConstRing for T where T: Ring + ConstSemiring {}
+define_blanket_trait! {
+    /// [`Ring`] with a bunch of values known at compile time.
+    pub trait ConstRing: Ring + ConstSemiring
+}
 
-/// Ring of integers, usually denoted as `Z`.
-pub trait IntRing: Ring + IntSemiringWithDivRem + Signed {}
-impl<T> IntRing for T where T: Ring + IntSemiringWithDivRem + Signed {}
+define_blanket_trait! {
+    /// Ring of integers, usually denoted as `Z`.
+    pub trait IntRing: Ring + IntSemiringWithDivRem + Signed
+}
 
-pub trait IntRingWithShifts: IntRing + IntSemiringWithShifts {}
-impl<T> IntRingWithShifts for T where T: IntRing + IntSemiringWithShifts {}
+define_blanket_trait! {
+    pub trait IntRingWithShifts: IntRing + IntSemiringWithShifts
+}
 
-pub trait ConstIntRing: IntRing + ConstIntSemiring + From<i8> {}
-impl<T> ConstIntRing for T where T: IntRing + ConstIntSemiring + From<i8> {}
+define_blanket_trait! {
+    pub trait ConstIntRing: IntRing + ConstIntSemiring + From<i8>
+}
 
 /// See [module-level documentation](crate::ring).
 pub trait RingConfig: SemiringConfig {
@@ -50,8 +55,9 @@ pub trait RingConfig: SemiringConfig {
     }
 }
 
-pub trait IntRingConfig: RingConfig + IntSemiringConfig {}
-impl<R> IntRingConfig for R where R: RingConfig + IntSemiringConfig {}
+define_blanket_trait! {
+    pub trait IntRingConfig: RingConfig + IntSemiringConfig
+}
 
 pub trait ConstIntRingConfig: IntRingConfig + ConstIntSemiringConfig {
     /// |x|

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{ConstSemiring, boolean::Boolean, crypto_bigint_uint::Uint, pow_via_repeated_squaring};
+use crate::{
+    ConstSemiring, WORD_FACTOR, boolean::Boolean, crypto_bigint_uint::Uint,
+    pow_via_repeated_squaring,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -21,7 +24,7 @@ use pastey::paste;
 #[cfg(feature = "rand")]
 use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Int<const LIMBS: usize>(crypto_bigint::Int<LIMBS>);
 
@@ -46,10 +49,16 @@ impl<const LIMBS: usize> Int<LIMBS> {
         unsafe { &mut *(value as *mut crypto_bigint::Int<LIMBS> as *mut Self) }
     }
 
-    /// Get the reference to the wrapped value
+    /// Get a reference to the wrapped value
     #[inline(always)]
     pub const fn inner(&self) -> &crypto_bigint::Int<LIMBS> {
         &self.0
+    }
+
+    /// Get a mutable reference to the wrapped value
+    #[inline(always)]
+    pub const fn inner_mut(&mut self) -> &mut crypto_bigint::Int<LIMBS> {
+        &mut self.0
     }
 
     /// Get the wrapped value, consuming self
@@ -77,7 +86,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
         }
     }
 
-    /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
+    /// See [crypto_bigint::Int::concatenating_mul]
+    #[inline(always)]
     pub const fn concatenating_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -89,13 +99,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
         Int(self.0.concatenating_mul(&rhs.0))
     }
 
-    /// See [crypto_bigint::Int::cmp_vartime]
-    pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
-        self.0.cmp_vartime(&rhs.0)
-    }
-
     pub const fn as_uint(&self) -> &Uint<LIMBS> {
         Uint::new_ref(self.0.as_uint())
+    }
+
+    /// See [crypto_bigint::Int::abs_sign]
+    pub fn abs_sign(&self) -> (Uint<LIMBS>, bool) {
+        let (abs, _) = self.0.abs_sign();
+        (Uint::new(abs), self.is_negative())
     }
 }
 
@@ -155,6 +166,19 @@ impl<const LIMBS: usize> Default for Int<LIMBS> {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
+    }
+}
+
+impl<const LIMBS: usize> PartialOrd for Int<LIMBS> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Implemented manually to use `cmp_vartime`
+impl<const LIMBS: usize> Ord for Int<LIMBS> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp_vartime(&other.0)
     }
 }
 
@@ -483,6 +507,20 @@ impl<const LIMBS: usize> From<Int<LIMBS>> for crypto_bigint::Int<LIMBS> {
     }
 }
 
+impl<'a, const LIMBS: usize> From<&'a crypto_bigint::Int<LIMBS>> for &'a Int<LIMBS> {
+    #[inline(always)]
+    fn from(value: &'a crypto_bigint::Int<LIMBS>) -> Self {
+        Int::new_ref(value)
+    }
+}
+
+impl<'a, const LIMBS: usize> From<&'a Int<LIMBS>> for &'a crypto_bigint::Int<LIMBS> {
+    #[inline(always)]
+    fn from(value: &'a Int<LIMBS>) -> Self {
+        &value.0
+    }
+}
+
 impl<const LIMBS: usize> From<bool> for Int<LIMBS> {
     #[inline(always)]
     fn from(value: bool) -> Self {
@@ -601,25 +639,30 @@ impl<const LIMBS: usize> ConstSemiring for Int<LIMBS> {
 impl<const LIMBS: usize> Ring for Int<LIMBS> {}
 
 impl<const LIMBS: usize> IntSemiring for Int<LIMBS> {
+    #[inline(always)]
     fn is_odd(&self) -> bool {
         self.0.is_odd().into()
     }
 
+    #[inline(always)]
     fn is_even(&self) -> bool {
         self.0.is_even().into()
     }
 }
 
 impl<const LIMBS: usize> IntRing for Int<LIMBS> {
+    #[inline(always)]
     fn is_positive(&self) -> bool {
         self.0.is_positive().into()
     }
 
+    #[inline(always)]
     fn checked_abs(&self) -> Option<Self> {
         let result: Option<_> = self.0.abs().try_into_int().into();
         result.map(Self)
     }
 
+    #[inline(always)]
     fn is_negative(&self) -> bool {
         self.0.is_negative().into()
     }
@@ -720,6 +763,40 @@ impl<const LIMBS: usize> crypto_bigint::Constants for Int<LIMBS> {
     const MAX: Self = ConstSemiring::MAX;
 }
 
+//
+// Predefined ints of various sizes for convenience
+//
+
+pub type I64 = Int<{ 1 * WORD_FACTOR }>;
+pub type I128 = Int<{ 2 * WORD_FACTOR }>;
+pub type I192 = Int<{ 3 * WORD_FACTOR }>;
+pub type I256 = Int<{ 4 * WORD_FACTOR }>;
+pub type I320 = Int<{ 5 * WORD_FACTOR }>;
+pub type I384 = Int<{ 6 * WORD_FACTOR }>;
+pub type I448 = Int<{ 7 * WORD_FACTOR }>;
+pub type I512 = Int<{ 8 * WORD_FACTOR }>;
+pub type I576 = Int<{ 9 * WORD_FACTOR }>;
+pub type I640 = Int<{ 10 * WORD_FACTOR }>;
+pub type I704 = Int<{ 11 * WORD_FACTOR }>;
+pub type I768 = Int<{ 12 * WORD_FACTOR }>;
+pub type I832 = Int<{ 13 * WORD_FACTOR }>;
+pub type I896 = Int<{ 14 * WORD_FACTOR }>;
+pub type I960 = Int<{ 15 * WORD_FACTOR }>;
+pub type I1024 = Int<{ 16 * WORD_FACTOR }>;
+pub type I1280 = Int<{ 20 * WORD_FACTOR }>;
+pub type I1536 = Int<{ 24 * WORD_FACTOR }>;
+pub type I1792 = Int<{ 28 * WORD_FACTOR }>;
+pub type I2048 = Int<{ 32 * WORD_FACTOR }>;
+pub type I3072 = Int<{ 48 * WORD_FACTOR }>;
+pub type I3584 = Int<{ 56 * WORD_FACTOR }>;
+pub type I4096 = Int<{ 64 * WORD_FACTOR }>;
+pub type I4224 = Int<{ 66 * WORD_FACTOR }>;
+pub type I4352 = Int<{ 68 * WORD_FACTOR }>;
+pub type I6144 = Int<{ 96 * WORD_FACTOR }>;
+pub type I8192 = Int<{ 128 * WORD_FACTOR }>;
+pub type I16384 = Int<{ 256 * WORD_FACTOR }>;
+pub type I32768 = Int<{ 512 * WORD_FACTOR }>;
+
 #[allow(clippy::arithmetic_side_effects, clippy::cast_lossless)]
 #[cfg(test)]
 mod tests {
@@ -737,7 +814,7 @@ mod tests {
     type Int4 = Int<{ WORD_FACTOR * 4 }>;
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         ensure_type_implements_trait!(Int4, ConstIntRing);
         ensure_type_implements_trait!(Int4, IntRingWithRem);
         ensure_type_implements_trait!(Int4, IntRingWithShifts);
@@ -1218,14 +1295,14 @@ mod tests {
     }
 
     #[test]
-    fn cmp_vartime() {
+    fn cmp() {
         let a = Int4::from(10_i64);
         let b = Int4::from(20_i64);
         let c = Int4::from(10_i64);
 
-        assert_eq!(a.cmp_vartime(&b), Ordering::Less);
-        assert_eq!(b.cmp_vartime(&a), Ordering::Greater);
-        assert_eq!(a.cmp_vartime(&c), Ordering::Equal);
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&a), Ordering::Greater);
+        assert_eq!(a.cmp(&c), Ordering::Equal);
     }
 
     #[test]

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    ConstSemiring, WORD_FACTOR, boolean::Boolean, crypto_bigint_uint::Uint,
+    ConstSemiring, WORD_FACTOR, Wrapper, boolean::Boolean, crypto_bigint_uint::Uint,
     pow_via_repeated_squaring,
 };
 use core::{
@@ -26,7 +26,7 @@ use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct Int<const LIMBS: usize>(crypto_bigint::Int<LIMBS>);
+pub struct Int<const LIMBS: usize>(pub crypto_bigint::Int<LIMBS>);
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Wraps a given value into this wrapper type
@@ -47,24 +47,6 @@ impl<const LIMBS: usize> Int<LIMBS> {
         // Safety: Int<LIMBS> is #[repr(transparent)] and is guaranteed to have the
         // same memory layout as crypto_bigint::Int
         unsafe { &mut *(value as *mut crypto_bigint::Int<LIMBS> as *mut Self) }
-    }
-
-    /// Get a reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner(&self) -> &crypto_bigint::Int<LIMBS> {
-        &self.0
-    }
-
-    /// Get a mutable reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner_mut(&mut self) -> &mut crypto_bigint::Int<LIMBS> {
-        &mut self.0
-    }
-
-    /// Get the wrapped value, consuming self
-    #[inline(always)]
-    pub const fn into_inner(self) -> crypto_bigint::Int<LIMBS> {
-        self.0
     }
 
     /// See [crypto_bigint::Int::from_words]
@@ -626,6 +608,34 @@ impl<const LIMBS: usize, const LIMBS2: usize> TryFrom<&crypto_bigint::Uint<LIMBS
 }
 
 //
+// Wrapper
+//
+
+impl<const LIMBS: usize> Wrapper for Int<LIMBS> {
+    type Inner = crypto_bigint::Int<LIMBS>;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
+    }
+}
+
+//
 // Semiring and Ring
 //
 
@@ -815,6 +825,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(Int4, Wrapper);
         ensure_type_implements_trait!(Int4, ConstIntRing);
         ensure_type_implements_trait!(Int4, IntRingWithRem);
         ensure_type_implements_trait!(Int4, IntRingWithShifts);

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -777,7 +777,7 @@ impl<const LIMBS: usize> crypto_bigint::Constants for Int<LIMBS> {
 // Predefined ints of various sizes for convenience
 //
 
-pub type I64 = Int<{ 1 * WORD_FACTOR }>;
+pub type I64 = Int<{ WORD_FACTOR }>;
 pub type I128 = Int<{ 2 * WORD_FACTOR }>;
 pub type I192 = Int<{ 3 * WORD_FACTOR }>;
 pub type I256 = Int<{ 4 * WORD_FACTOR }>;

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::{
-    ConstSemiring, WORD_FACTOR, Wrapper, boolean::Boolean, crypto_bigint_uint::Uint,
-    pow_via_repeated_squaring,
+    ConstSemiring, Wrapper, boolean::Boolean, crypto_bigint_uint::Uint, pow_via_repeated_squaring,
 };
 use core::{
     cmp::Ordering,
@@ -777,6 +776,7 @@ impl<const LIMBS: usize> crypto_bigint::Constants for Int<LIMBS> {
 // Predefined ints of various sizes for convenience
 //
 
+use crate::helpers::crypto_bigint::WORD_FACTOR;
 pub type I64 = Int<{ WORD_FACTOR }>;
 pub type I128 = Int<{ 2 * WORD_FACTOR }>;
 pub type I192 = Int<{ 3 * WORD_FACTOR }>;

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::{Wrapper, boolean::Boolean, crypto_bigint_uint::Uint, pow_via_repeated_squaring};
+use crate::{
+    Wrapper, boolean::Boolean, crypto_bigint_uint::Uint, helpers::pow_via_repeated_squaring,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -164,18 +164,21 @@ impl<const LIMBS: usize> Ord for Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> LowerHex for Int<LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         LowerHex::fmt(&self.0, f)
     }
 }
 
 impl<const LIMBS: usize> UpperHex for Int<LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         UpperHex::fmt(&self.0, f)
     }
 }
 
 impl<const LIMBS: usize> Hash for Int<LIMBS> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state)
     }

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,22 +1,20 @@
 use super::*;
-use crate::{
-    ConstSemiring, Wrapper, boolean::Boolean, crypto_bigint_uint::Uint, pow_via_repeated_squaring,
-};
+use crate::{Wrapper, boolean::Boolean, crypto_bigint_uint::Uint, pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
     ops::{
-        Add, AddAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
-        SubAssign,
+        Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, ShlAssign, Shr,
+        ShrAssign, Sub, SubAssign,
     },
     str::FromStr,
 };
 use crypto_bigint::{CheckedSub as CryptoCheckedSub, Integer, Word};
 use num_traits::{
-    CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, ConstOne, ConstZero, One, Pow,
-    WrappingAdd, WrappingMul, WrappingSub, Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, ConstOne,
+    ConstZero, Num, One, Pow, Signed, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use pastey::paste;
 
@@ -89,6 +87,20 @@ impl<const LIMBS: usize> Int<LIMBS> {
         let (abs, _) = self.0.abs_sign();
         (Uint::new(abs), self.is_negative())
     }
+
+    /// Parses the absolute value from `s` and applies the sign.
+    fn parse_abs_radix(s: &str, radix: u32, neg: bool) -> Option<Self> {
+        use crypto_bigint::Uint;
+        let abs = Uint::<LIMBS>::from_str_radix_vartime(s, radix).ok()?;
+        match Self::try_from(abs) {
+            Ok(res) if neg => res.checked_neg(),
+            Ok(res) => Some(res),
+            // Corner case: value is exactly minimum Int<LIMBS>, whose
+            // magnitude is MIN's own bit pattern reinterpreted as unsigned
+            _ if neg && abs == Self::MIN.as_uint().0 => Some(Self::MIN),
+            _ => None,
+        }
+    }
 }
 
 const fn checked_resize<const SRC: usize, const DST: usize>(
@@ -124,7 +136,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// The number of limbs used on this platform.
     pub const LIMBS: usize = LIMBS;
 
-    define_consts!(MINUS_ONE, SIGN_MASK);
+    define_consts!(MAX, MIN, MINUS_ONE, SIGN_MASK);
 }
 
 //
@@ -187,7 +199,6 @@ impl<const LIMBS: usize> Hash for Int<LIMBS> {
 impl<const LIMBS: usize> FromStr for Int<LIMBS> {
     type Err = ();
 
-    #[allow(clippy::arithmetic_side_effects)] // False positive
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (neg, s) = if let Some(s) = s.strip_prefix('-') {
             (true, s)
@@ -199,16 +210,20 @@ impl<const LIMBS: usize> FromStr for Int<LIMBS> {
         } else {
             (10, s)
         };
-        use crypto_bigint::Uint;
-        let abs = Uint::<LIMBS>::from_str_radix_vartime(s, radix).map_err(|_| ())?;
-        let res: Result<Self, _> = abs.try_into();
-        match res {
-            Ok(res) if neg => res.checked_neg().ok_or(()),
-            Ok(res) => Ok(res),
-            // Corner case: value is exactly minimum Int<LIMBS>
-            _ if neg && abs == (Uint::MAX.shr(1) + Uint::one()) => Ok(Int::<LIMBS>::MIN),
-            _ => Err(()),
-        }
+        Self::parse_abs_radix(s, radix, neg).ok_or(())
+    }
+}
+
+impl<const LIMBS: usize> Num for Int<LIMBS> {
+    type FromStrRadixErr = ();
+
+    fn from_str_radix(s: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        let (neg, s) = if let Some(s) = s.strip_prefix('-') {
+            (true, s)
+        } else {
+            (false, s)
+        };
+        Self::parse_abs_radix(s, radix, neg).ok_or(())
     }
 }
 
@@ -318,6 +333,25 @@ impl<'a, const LIMBS: usize> Rem<&'a Self> for Int<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> Div for Int<LIMBS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn div(self, rhs: Self) -> Self::Output {
+        self.div(&rhs)
+    }
+}
+
+impl<'a, const LIMBS: usize> Div<&'a Self> for Int<LIMBS> {
+    type Output = Self;
+
+    /// Truncated division (mirrors primitive `/`), variable-time in `rhs`.
+    fn div(self, rhs: &'a Self) -> Self::Output {
+        let quotient: Option<crypto_bigint::Int<LIMBS>> = self.0.checked_div_vartime(&rhs.0).into();
+        Self(quotient.expect("division by zero or overflow"))
+    }
+}
+
 impl<const LIMBS: usize> Shl<u32> for Int<LIMBS> {
     type Output = Self;
 
@@ -382,6 +416,16 @@ impl<const LIMBS: usize> CheckedRem for Int<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> CheckedDiv for Int<LIMBS> {
+    /// Truncated division, variable-time in `other`. Returns [`None`] on
+    /// division by zero or `MIN / -1` overflow.
+    fn checked_div(&self, other: &Self) -> Option<Self> {
+        let quotient: Option<crypto_bigint::Int<LIMBS>> =
+            self.0.checked_div_vartime(&other.0).into();
+        quotient.map(Self)
+    }
+}
+
 //
 // Arithmetic assign operations
 //
@@ -407,6 +451,20 @@ macro_rules! impl_assign_op {
 impl_assign_op!(AddAssign, add_assign);
 impl_assign_op!(SubAssign, sub_assign);
 impl_assign_op!(MulAssign, mul_assign);
+
+impl<const LIMBS: usize> DivAssign for Int<LIMBS> {
+    #[inline(always)]
+    fn div_assign(&mut self, rhs: Self) {
+        self.div_assign(&rhs);
+    }
+}
+
+impl<'a, const LIMBS: usize> DivAssign<&'a Self> for Int<LIMBS> {
+    #![allow(clippy::arithmetic_side_effects)]
+    fn div_assign(&mut self, rhs: &'a Self) {
+        *self = (*self).div(rhs);
+    }
+}
 
 impl<const LIMBS: usize> RemAssign for Int<LIMBS> {
     #[inline(always)]
@@ -641,14 +699,17 @@ impl<const LIMBS: usize> Wrapper for Int<LIMBS> {
 // Semiring and Ring
 //
 
-impl<const LIMBS: usize> Semiring for Int<LIMBS> {}
+impl<const LIMBS: usize> Bounded for Int<LIMBS> {
+    #[inline(always)]
+    fn min_value() -> Self {
+        Self::MIN
+    }
 
-impl<const LIMBS: usize> ConstSemiring for Int<LIMBS> {
-    const MAX: Self = Self(crypto_bigint::Int::MAX);
-    const MIN: Self = Self(crypto_bigint::Int::MIN);
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::MAX
+    }
 }
-
-impl<const LIMBS: usize> Ring for Int<LIMBS> {}
 
 impl<const LIMBS: usize> IntSemiring for Int<LIMBS> {
     #[inline(always)]
@@ -662,16 +723,41 @@ impl<const LIMBS: usize> IntSemiring for Int<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> IntRing for Int<LIMBS> {
-    #[inline(always)]
-    fn is_positive(&self) -> bool {
-        self.0.is_positive().into()
+impl<const LIMBS: usize> Signed for Int<LIMBS> {
+    /// Mimics Rust's primitive behavior: panics in debug mode on `MIN` (whose
+    /// absolute value overflows), wraps in release mode.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn abs(&self) -> Self {
+        if Signed::is_negative(self) {
+            -*self
+        } else {
+            *self
+        }
+    }
+
+    /// Mimics Rust's primitive overflow behavior for `self - other`.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn abs_sub(&self, other: &Self) -> Self {
+        if self <= other {
+            Self::ZERO
+        } else {
+            *self - *other
+        }
+    }
+
+    fn signum(&self) -> Self {
+        if Signed::is_negative(self) {
+            Self::MINUS_ONE
+        } else if self.is_zero() {
+            Self::ZERO
+        } else {
+            Self::ONE
+        }
     }
 
     #[inline(always)]
-    fn checked_abs(&self) -> Option<Self> {
-        let result: Option<_> = self.0.abs().try_into_int().into();
-        result.map(Self)
+    fn is_positive(&self) -> bool {
+        self.0.is_positive().into()
     }
 
     #[inline(always)]
@@ -772,7 +858,7 @@ impl<const LIMBS: usize> crypto_bigint::Bounded for Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> crypto_bigint::Constants for Int<LIMBS> {
-    const MAX: Self = ConstSemiring::MAX;
+    const MAX: Self = Self::MAX;
 }
 
 //
@@ -830,7 +916,6 @@ mod tests {
     fn ensure_traits() {
         ensure_type_implements_trait!(Int4, Wrapper);
         ensure_type_implements_trait!(Int4, ConstIntRing);
-        ensure_type_implements_trait!(Int4, IntRingWithRem);
         ensure_type_implements_trait!(Int4, IntRingWithShifts);
     }
 
@@ -1382,7 +1467,7 @@ mod tests {
         assert_eq!(<Int4 as Bounded>::BYTES, 32);
 
         // Test Constants trait
-        assert_eq!(<Int4 as Constants>::MAX, <Int4 as ConstSemiring>::MAX);
+        assert_eq!(<Int4 as Constants>::MAX, Int4::MAX);
     }
 
     #[test]

--- a/src/semiring.rs
+++ b/src/semiring.rs
@@ -1,3 +1,16 @@
+//! This module defines **semirings** - sets equipped with addition and
+//! multiplication.
+//!
+//! Even though subtraction is not required (additive inverses are not
+//! guaranteed to exist), we include subtraction in the definition for
+//! convenience.
+//!
+//! See the [crate-level documentation](crate) for the overall element/config
+//! structure.
+//!
+//! This module additionally defines several specialized flavors of semirings
+//! for working with integers.
+
 #[cfg(feature = "ark_ff")]
 pub mod ark_ff_bigint;
 pub mod boolean;
@@ -6,34 +19,31 @@ pub mod crypto_bigint_boxed_uint;
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_uint;
 
+use crate::{FixedConfig, ParseStrConfig, SetConfig, SetElement, delegate_to_ref_binary};
 use core::{
-    fmt::{Debug, Display},
+    fmt::Display,
     hash::Hash,
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign},
+    ops::{
+        Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr,
+        ShrAssign, Sub, SubAssign,
+    },
     str::FromStr,
 };
-use num_traits::{CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, One, Pow, Zero};
+use num_traits::{
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub, ConstOne, ConstZero, One,
+    Pow, Zero,
+};
+use pastey::paste;
 
-/// A semiring is a mathematical structure that consists of a set equipped with
-/// two binary operations: addition and multiplication. The addition operation
-/// is commutative and associative, has an identity element (zero), and every
-/// element has an additive inverse. The multiplication operation is
-/// associative, has an identity element (one), and distributes over addition.
-/// However, unlike a ring, a semiring does not require the existence of
-/// additive inverses for all elements.
-/// Even though subtraction is not required, we include it here for convenience.
+/// See [module-level documentation](crate::semiring).
 pub trait Semiring:
+    SetElement
     // Core traits
-    Sized
-    + Debug
+    + Sized
     + Display
-    + Clone
-    + PartialEq
-    + Eq
-    + Sync
-    + Send
     + Hash
+    + Default
     // Arithmetic operations consuming rhs
     + CheckedAdd
     + CheckedSub
@@ -41,6 +51,7 @@ pub trait Semiring:
     + AddAssign
     + SubAssign
     + MulAssign
+    + Pow<u32, Output=Self>
     // Arithmetic operations with rhs reference
     + for<'a> Add<&'a Self, Output=Self>
     + for<'a> Sub<&'a Self, Output=Self>
@@ -48,50 +59,87 @@ pub trait Semiring:
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
     + for<'a> MulAssign<&'a Self>
-    {}
-
-/// Semiring whose zero and one elements can be constructed from the type alone.
-pub trait FixedSemiring:
-    Semiring
+    // Aggregate operations
     + Sum
     + Product
     + for<'a> Sum<&'a Self>
     + for<'a> Product<&'a Self>
-    + Default
+    // Other
     + Zero
     + One
     + From<bool>
-{
-}
-impl<T> FixedSemiring for T where
-    T: Semiring
+    {}
+
+impl<T> Semiring for T where
+    T: SetElement
+        // Core traits
+        + Sized
+        + Display
+        + Hash
+        + Default
+        // Arithmetic operations consuming rhs
+        + CheckedAdd
+        + CheckedSub
+        + CheckedMul
+        + AddAssign
+        + SubAssign
+        + MulAssign
+        + Pow<u32, Output = Self>
+        // Arithmetic operations with rhs reference
+        + for<'a> Add<&'a Self, Output = Self>
+        + for<'a> Sub<&'a Self, Output = Self>
+        + for<'a> Mul<&'a Self, Output = Self>
+        + for<'a> AddAssign<&'a Self>
+        + for<'a> SubAssign<&'a Self>
+        + for<'a> MulAssign<&'a Self>
+        // Aggregate operations
         + Sum
         + Product
         + for<'a> Sum<&'a Self>
         + for<'a> Product<&'a Self>
-        + Default
+        // Other
         + Zero
         + One
         + From<bool>
 {
 }
 
-/// Semiring with a bunch of values known at compile time.
-pub trait ConstSemiring: FixedSemiring + ConstZero + ConstOne {
-    /// Minimum value of the semiring. For fields, this is the smallest
-    /// representable value.
-    const MIN: Self;
+/// [`Semiring`] with a bunch of values known at compile time.
+pub trait ConstSemiring: Semiring + ConstZero + ConstOne {}
+impl<S: Semiring + ConstZero + ConstOne> ConstSemiring for S {}
 
-    /// Maximum value of the semiring. For fields, this is the largest
-    /// representable value.
-    const MAX: Self;
-}
-
-/// Semiring of integers
-pub trait IntSemiring: Semiring + PartialOrd + Pow<u32> {
+/// Semiring of integers.
+pub trait IntSemiring: Semiring + Ord {
     fn is_odd(&self) -> bool;
 
     fn is_even(&self) -> bool;
+}
+
+/// [`IntSemiring`] that defines (integer) division and remainder operations.
+pub trait IntSemiringWithDivRem:
+    IntSemiring
+    + CheckedDiv
+    + CheckedRem
+    + for<'a> Div<&'a Self, Output = Self>
+    + for<'a> Rem<&'a Self, Output = Self>
+    + DivAssign
+    + RemAssign
+    + for<'a> DivAssign<&'a Self>
+    + for<'a> RemAssign<&'a Self>
+{
+}
+
+impl<T> IntSemiringWithDivRem for T where
+    T: IntSemiring
+        + CheckedDiv
+        + CheckedRem
+        + for<'a> Div<&'a Self, Output = Self>
+        + for<'a> Rem<&'a Self, Output = Self>
+        + DivAssign
+        + RemAssign
+        + for<'a> DivAssign<&'a Self>
+        + for<'a> RemAssign<&'a Self>
+{
 }
 
 pub trait IntSemiringWithShifts:
@@ -103,16 +151,11 @@ impl<T> IntSemiringWithShifts for T where
 {
 }
 
-pub trait ConstIntSemiring: IntSemiring + ConstSemiring + Ord + FromStr {}
-impl<T> ConstIntSemiring for T where T: IntSemiring + ConstSemiring + Ord + FromStr {}
+pub trait ConstIntSemiring: IntSemiring + ConstSemiring + Bounded + FromStr {}
+impl<T> ConstIntSemiring for T where T: IntSemiring + ConstSemiring + Bounded + FromStr {}
 
 macro_rules! primitive_int_semiring {
     ($t:ident) => {
-        impl Semiring for $t {}
-        impl ConstSemiring for $t {
-            const MAX: Self = $t::MAX;
-            const MIN: Self = $t::MIN;
-        }
         impl IntSemiring for $t {
             fn is_odd(&self) -> bool {
                 *self & 1 == 1
@@ -135,3 +178,231 @@ primitive_int_semiring!(u16);
 primitive_int_semiring!(u32);
 primitive_int_semiring!(u64);
 primitive_int_semiring!(u128);
+
+/// See [module-level documentation](crate::semiring).
+pub trait SemiringConfig: SetConfig {
+    fn is_zero(&self, value: &Self::Element) -> bool;
+
+    fn zero(&self) -> Self::Element;
+
+    fn one(&self) -> Self::Element;
+
+    //
+    // Operations on refs
+    //
+
+    /// x + y
+    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
+
+    /// x - y
+    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
+
+    /// x * y
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element;
+
+    /// x ** y
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element;
+
+    //
+    // Checked operations on refs
+    //
+
+    /// x + y
+    fn checked_add(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element>;
+
+    /// x - y
+    fn checked_sub(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element>;
+
+    /// x * y
+    fn checked_mul(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element>;
+
+    /// x ** y
+    fn checked_pow_u32(&self, x: &Self::Element, y: u32) -> Option<Self::Element>;
+
+    //
+    // Operations on mutable refs
+    //
+
+    delegate_to_ref_binary! {
+        /// x += y
+        add
+    }
+
+    delegate_to_ref_binary! {
+        /// x -= y
+        sub
+    }
+
+    delegate_to_ref_binary! {
+        /// x *= y
+        mul
+    }
+
+    delegate_to_ref_binary! {
+        /// x **= y
+        pow_u32(u32)
+    }
+
+    //
+    // Aggregate operations
+    //
+
+    fn sum<I: Iterator<Item = Self::Element>>(&self, mut iter: I) -> Self::Element {
+        let mut acc = iter.next().unwrap_or(self.zero());
+        for x in iter {
+            self.add_assign(&mut acc, &x)
+        }
+        acc
+    }
+
+    fn sum_refs<'a, I: Iterator<Item = &'a Self::Element> + 'a>(
+        &self,
+        mut iter: I,
+    ) -> Self::Element {
+        let mut acc = iter.next().cloned().unwrap_or(self.zero());
+        for x in iter {
+            self.add_assign(&mut acc, x)
+        }
+        acc
+    }
+
+    fn product<I: Iterator<Item = Self::Element>>(&self, mut iter: I) -> Self::Element {
+        let mut acc = iter.next().unwrap_or(self.one());
+        for x in iter {
+            self.mul_assign(&mut acc, &x)
+        }
+        acc
+    }
+
+    fn product_refs<'a, I: Iterator<Item = &'a Self::Element>>(
+        &self,
+        mut iter: I,
+    ) -> Self::Element {
+        let mut acc = iter.next().cloned().unwrap_or(self.one());
+        for x in iter {
+            self.mul_assign(&mut acc, x)
+        }
+        acc
+    }
+}
+
+pub trait IntSemiringConfig: SemiringConfig {
+    fn is_odd(&self, x: &Self::Element) -> bool;
+
+    fn is_even(&self, x: &Self::Element) -> bool;
+}
+
+pub trait ConstIntSemiringConfig: IntSemiringConfig + ParseStrConfig {
+    fn min(&self) -> Self::Element;
+
+    fn max(&self) -> Self::Element;
+}
+
+// Delegating to the element's own (potentially overflowing) operators is the
+// whole point of this bridge.
+#[allow(clippy::arithmetic_side_effects)]
+impl<S: Semiring> SemiringConfig for FixedConfig<S> {
+    #[inline(always)]
+    fn is_zero(&self, value: &Self::Element) -> bool {
+        value.is_zero()
+    }
+
+    #[inline(always)]
+    fn zero(&self) -> Self::Element {
+        S::zero()
+    }
+
+    #[inline(always)]
+    fn one(&self) -> Self::Element {
+        S::one()
+    }
+
+    #[inline(always)]
+    fn add(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.clone() + y
+    }
+
+    #[inline(always)]
+    fn sub(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.clone() - y
+    }
+
+    #[inline(always)]
+    fn mul(&self, x: &Self::Element, y: &Self::Element) -> Self::Element {
+        x.clone() * y
+    }
+
+    #[inline(always)]
+    fn pow_u32(&self, x: &Self::Element, y: u32) -> Self::Element {
+        x.clone().pow(y)
+    }
+
+    fn checked_add(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        x.checked_add(y)
+    }
+
+    fn checked_sub(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        x.checked_sub(y)
+    }
+
+    fn checked_mul(&self, x: &Self::Element, y: &Self::Element) -> Option<Self::Element> {
+        x.checked_mul(y)
+    }
+
+    fn checked_pow_u32(&self, x: &Self::Element, y: u32) -> Option<Self::Element> {
+        num_traits::checked_pow(x.clone(), usize::try_from(y).ok()?)
+    }
+
+    fn add_assign(&self, x: &mut Self::Element, y: &Self::Element) {
+        *x += y
+    }
+
+    fn sub_assign(&self, x: &mut Self::Element, y: &Self::Element) {
+        *x -= y;
+    }
+
+    fn mul_assign(&self, x: &mut Self::Element, y: &Self::Element) {
+        *x *= y
+    }
+}
+
+impl<S: SetElement + FromStr> ParseStrConfig for FixedConfig<S> {
+    fn parse_str(&self, str: &str) -> Option<Self::Element> {
+        str.parse().ok()
+    }
+}
+
+impl<S: IntSemiring> IntSemiringConfig for FixedConfig<S> {
+    fn is_odd(&self, x: &Self::Element) -> bool {
+        IntSemiring::is_odd(x)
+    }
+
+    fn is_even(&self, x: &Self::Element) -> bool {
+        IntSemiring::is_even(x)
+    }
+}
+
+impl<S: ConstIntSemiring> ConstIntSemiringConfig for FixedConfig<S> {
+    fn min(&self) -> Self::Element {
+        S::min_value()
+    }
+
+    fn max(&self) -> Self::Element {
+        S::max_value()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ensure_type_implements_trait;
+
+    #[test]
+    fn ensure_traits() {
+        ensure_type_implements_trait!(u8, ConstIntSemiring);
+        ensure_type_implements_trait!(i128, ConstIntSemiring);
+
+        ensure_type_implements_trait!(FixedConfig<u8>, ConstIntSemiringConfig);
+        ensure_type_implements_trait!(FixedConfig<i128>, ConstIntSemiringConfig);
+    }
+}

--- a/src/semiring.rs
+++ b/src/semiring.rs
@@ -19,7 +19,10 @@ pub mod crypto_bigint_boxed_uint;
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_uint;
 
-use crate::{FixedConfig, ParseStrConfig, SetConfig, SetElement, delegate_to_ref_binary};
+use crate::{
+    FixedConfig, ParseStrConfig, SetConfig, SetElement,
+    helpers::{define_blanket_trait, delegate_to_ref_binary},
+};
 use core::{
     fmt::Display,
     hash::Hash,
@@ -36,42 +39,10 @@ use num_traits::{
 };
 use pastey::paste;
 
-/// See [module-level documentation](crate::semiring).
-pub trait Semiring:
-    SetElement
-    // Core traits
-    + Sized
-    + Display
-    + Hash
-    + Default
-    // Arithmetic operations consuming rhs
-    + CheckedAdd
-    + CheckedSub
-    + CheckedMul
-    + AddAssign
-    + SubAssign
-    + MulAssign
-    + Pow<u32, Output=Self>
-    // Arithmetic operations with rhs reference
-    + for<'a> Add<&'a Self, Output=Self>
-    + for<'a> Sub<&'a Self, Output=Self>
-    + for<'a> Mul<&'a Self, Output=Self>
-    + for<'a> AddAssign<&'a Self>
-    + for<'a> SubAssign<&'a Self>
-    + for<'a> MulAssign<&'a Self>
-    // Aggregate operations
-    + Sum
-    + Product
-    + for<'a> Sum<&'a Self>
-    + for<'a> Product<&'a Self>
-    // Other
-    + Zero
-    + One
-    + From<bool>
-    {}
-
-impl<T> Semiring for T where
-    T: SetElement
+define_blanket_trait! {
+    /// See [module-level documentation](crate::semiring).
+    pub trait Semiring:
+        SetElement
         // Core traits
         + Sized
         + Display
@@ -84,11 +55,11 @@ impl<T> Semiring for T where
         + AddAssign
         + SubAssign
         + MulAssign
-        + Pow<u32, Output = Self>
+        + Pow<u32, Output=Self>
         // Arithmetic operations with rhs reference
-        + for<'a> Add<&'a Self, Output = Self>
-        + for<'a> Sub<&'a Self, Output = Self>
-        + for<'a> Mul<&'a Self, Output = Self>
+        + for<'a> Add<&'a Self, Output=Self>
+        + for<'a> Sub<&'a Self, Output=Self>
+        + for<'a> Mul<&'a Self, Output=Self>
         + for<'a> AddAssign<&'a Self>
         + for<'a> SubAssign<&'a Self>
         + for<'a> MulAssign<&'a Self>
@@ -101,12 +72,12 @@ impl<T> Semiring for T where
         + Zero
         + One
         + From<bool>
-{
 }
 
-/// [`Semiring`] with a bunch of values known at compile time.
-pub trait ConstSemiring: Semiring + ConstZero + ConstOne {}
-impl<S: Semiring + ConstZero + ConstOne> ConstSemiring for S {}
+define_blanket_trait! {
+    /// [`Semiring`] with a bunch of values known at compile time.
+    pub trait ConstSemiring: Semiring + ConstZero + ConstOne
+}
 
 /// Semiring of integers.
 pub trait IntSemiring: Semiring + Ord {
@@ -115,22 +86,10 @@ pub trait IntSemiring: Semiring + Ord {
     fn is_even(&self) -> bool;
 }
 
-/// [`IntSemiring`] that defines (integer) division and remainder operations.
-pub trait IntSemiringWithDivRem:
-    IntSemiring
-    + CheckedDiv
-    + CheckedRem
-    + for<'a> Div<&'a Self, Output = Self>
-    + for<'a> Rem<&'a Self, Output = Self>
-    + DivAssign
-    + RemAssign
-    + for<'a> DivAssign<&'a Self>
-    + for<'a> RemAssign<&'a Self>
-{
-}
-
-impl<T> IntSemiringWithDivRem for T where
-    T: IntSemiring
+define_blanket_trait! {
+    /// [`IntSemiring`] that defines (integer) division and remainder operations.
+    pub trait IntSemiringWithDivRem:
+        IntSemiring
         + CheckedDiv
         + CheckedRem
         + for<'a> Div<&'a Self, Output = Self>
@@ -139,20 +98,16 @@ impl<T> IntSemiringWithDivRem for T where
         + RemAssign
         + for<'a> DivAssign<&'a Self>
         + for<'a> RemAssign<&'a Self>
-{
 }
 
-pub trait IntSemiringWithShifts:
-    IntSemiring + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
-{
-}
-impl<T> IntSemiringWithShifts for T where
-    T: IntSemiring + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
-{
+define_blanket_trait! {
+    pub trait IntSemiringWithShifts:
+        IntSemiring + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
 }
 
-pub trait ConstIntSemiring: IntSemiring + ConstSemiring + Bounded + FromStr {}
-impl<T> ConstIntSemiring for T where T: IntSemiring + ConstSemiring + Bounded + FromStr {}
+define_blanket_trait! {
+    pub trait ConstIntSemiring: IntSemiring + ConstSemiring + Bounded + FromStr
+}
 
 macro_rules! primitive_int_semiring {
     ($t:ident) => {

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boolean::Boolean, pow_via_repeated_squaring};
+use crate::{Wrapper, boolean::Boolean, pow_via_repeated_squaring};
 use alloc::{format, vec::Vec};
 use ark_ff::{BigInt as ArkBigInt, BigInteger as ArkBigInteger};
 use ark_serialize::{
@@ -21,7 +21,7 @@ use rand::{distr::StandardUniform, prelude::*};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct BigInt<const N: usize>(ArkBigInt<N>);
+pub struct BigInt<const N: usize>(pub ArkBigInt<N>);
 
 impl<const N: usize> BigInt<N> {
     /// Size of the underlying limbs in bits
@@ -50,24 +50,6 @@ impl<const N: usize> BigInt<N> {
         // Safety: BigInt is #[repr(transparent)] and is guaranteed to have the
         // same memory layout as ArkBigInt
         unsafe { &mut *(value as *mut ArkBigInt<N> as *mut Self) }
-    }
-
-    /// Get the reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner(&self) -> &ArkBigInt<N> {
-        &self.0
-    }
-
-    /// Get the mutable reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner_mut(&mut self) -> &mut ArkBigInt<N> {
-        &mut self.0
-    }
-
-    /// Get the wrapped value, consuming self
-    #[inline(always)]
-    pub const fn into_inner(self) -> ArkBigInt<N> {
-        self.0
     }
 
     /// See [ArkBigInteger::new]
@@ -514,6 +496,34 @@ impl<const N: usize> TryFrom<num_bigint::BigUint> for BigInt<N> {
 }
 
 //
+// Wrapper
+//
+
+impl<const N: usize> Wrapper for BigInt<N> {
+    type Inner = ArkBigInt<N>;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
+    }
+}
+
+//
 // Semiring
 //
 
@@ -758,6 +768,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(BigInt4, Wrapper);
         ensure_type_implements_trait!(BigInt4, ConstIntSemiring);
         ensure_type_implements_trait!(BigInt4, IntSemiringWithShifts);
     }

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -15,7 +15,9 @@ use core::{
     },
     str::FromStr,
 };
-use num_traits::{CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, Num, One, Pow, Zero};
+use num_traits::{
+    Bounded, CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, Num, One, Pow, Zero,
+};
 #[cfg(feature = "rand")]
 use rand::{distr::StandardUniform, prelude::*};
 
@@ -31,6 +33,7 @@ impl<const N: usize> BigInt<N> {
     pub const BYTES: usize = Self::NUM_LIMBS * 8;
     /// Number of u64 limbs in the underlying representation
     pub const LIMBS: usize = N;
+    pub const MAX: Self = Self(ArkBigInt([u64::MAX; N]));
 
     /// Wraps a given value into this wrapper type
     #[inline(always)]
@@ -52,7 +55,7 @@ impl<const N: usize> BigInt<N> {
         unsafe { &mut *(value as *mut ArkBigInt<N> as *mut Self) }
     }
 
-    /// See [ArkBigInteger::new]
+    /// See [ArkBigInt::new]
     #[inline(always)]
     pub const fn from_limbs(arr: [u64; N]) -> Self {
         Self(ArkBigInt::new(arr))
@@ -527,11 +530,16 @@ impl<const N: usize> Wrapper for BigInt<N> {
 // Semiring
 //
 
-impl<const N: usize> Semiring for BigInt<N> {}
+impl<const N: usize> Bounded for BigInt<N> {
+    #[inline(always)]
+    fn min_value() -> Self {
+        Self::ZERO
+    }
 
-impl<const N: usize> ConstSemiring for BigInt<N> {
-    const MAX: Self = Self(ArkBigInt([u64::MAX; N]));
-    const MIN: Self = Self::ZERO;
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::MAX
+    }
 }
 
 impl<const N: usize> IntSemiring for BigInt<N> {
@@ -822,8 +830,8 @@ mod tests {
         assert!(b.checked_sub(&a).is_none());
 
         // MIN and MAX
-        assert_eq!(BigInt4::MAX.checked_add(&One::one()), None);
-        assert_eq!(BigInt4::MIN.checked_sub(&One::one()), None);
+        assert_eq!(BigInt4::max_value().checked_add(&One::one()), None);
+        assert_eq!(BigInt4::min_value().checked_sub(&One::one()), None);
     }
 
     #[allow(clippy::op_ref)]
@@ -940,7 +948,7 @@ mod tests {
     #[test]
     fn edge_cases() {
         // Test operations with MAX values
-        let max = BigInt4::MAX;
+        let max = BigInt4::max_value();
         let one = BigInt4::one();
 
         // MAX + 1 should overflow in checked_add
@@ -1021,7 +1029,7 @@ mod tests {
     #[test]
     fn formatting() {
         let a = BigInt1::from(255_u64);
-        let b = BigInt1::MAX;
+        let b = BigInt1::max_value();
 
         // Test Display
         assert_eq!(format!("{}", a), "255");
@@ -1042,7 +1050,7 @@ mod tests {
     #[test]
     fn constants() {
         // Test MAX
-        assert!(BigInt4::MAX > BigInt4::ZERO);
+        assert!(BigInt4::max_value() > BigInt4::ZERO);
 
         // Test BITS, BYTES, LIMBS
         assert_eq!(BigInt4::BITS, 256);
@@ -1078,7 +1086,7 @@ mod tests {
         assert_eq!(d, BigInt4::one());
         assert_eq!(
             u64::MAX.to_string().parse::<BigInt1>().unwrap(),
-            BigInt1::MAX
+            BigInt1::max_value()
         );
 
         assert_eq!("0xFF".parse::<BigInt4>().unwrap(), BigInt4::from(255_u64));

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Wrapper, boolean::Boolean, pow_via_repeated_squaring};
+use crate::{Wrapper, boolean::Boolean, helpers::pow_via_repeated_squaring};
 use alloc::{format, vec::Vec};
 use ark_ff::{BigInt as ArkBigInt, BigInteger as ArkBigInteger};
 use ark_serialize::{

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -525,10 +525,12 @@ impl<const N: usize> ConstSemiring for BigInt<N> {
 }
 
 impl<const N: usize> IntSemiring for BigInt<N> {
+    #[inline(always)]
     fn is_odd(&self) -> bool {
         self.0.is_odd()
     }
 
+    #[inline(always)]
     fn is_even(&self) -> bool {
         self.0.is_even()
     }
@@ -755,7 +757,7 @@ mod tests {
     type BigInt4 = BigInt<4>;
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         ensure_type_implements_trait!(BigInt4, ConstIntSemiring);
         ensure_type_implements_trait!(BigInt4, IntSemiringWithShifts);
     }

--- a/src/semiring/boolean.rs
+++ b/src/semiring/boolean.rs
@@ -385,10 +385,12 @@ impl ConstSemiring for Boolean {
 }
 
 impl IntSemiring for Boolean {
+    #[inline(always)]
     fn is_odd(&self) -> bool {
         self.0
     }
 
+    #[inline(always)]
     fn is_even(&self) -> bool {
         !self.0
     }
@@ -429,7 +431,7 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         ensure_type_implements_trait!(Boolean, ConstIntSemiring);
     }
 

--- a/src/semiring/boolean.rs
+++ b/src/semiring/boolean.rs
@@ -1,4 +1,4 @@
-use crate::{ConstSemiring, IntSemiring, Semiring, f2::F2};
+use crate::{ConstSemiring, IntSemiring, Semiring, Wrapper, f2::F2};
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::Hash,
@@ -17,7 +17,7 @@ use rand::{distr::StandardUniform, prelude::*};
 /// - In release mode: overflow wraps (e.g., true + true = false)
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct Boolean(bool);
+pub struct Boolean(pub bool);
 
 impl Boolean {
     pub const FALSE: Self = Self(false);
@@ -27,18 +27,6 @@ impl Boolean {
     #[inline(always)]
     pub const fn new(value: bool) -> Self {
         Self(value)
-    }
-
-    /// Get the inner bool value
-    #[inline(always)]
-    pub const fn inner(&self) -> bool {
-        self.0
-    }
-
-    /// Convert to the inner bool value
-    #[inline(always)]
-    pub const fn into_inner(self) -> bool {
-        self.0
     }
 
     /// Convert to u8 (0 or 1)
@@ -374,6 +362,34 @@ impl Pow<u32> for Boolean {
 }
 
 //
+// Wrapper
+//
+
+impl Wrapper for Boolean {
+    type Inner = bool;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
+    }
+}
+
+//
 // Semiring
 //
 
@@ -427,11 +443,12 @@ impl zeroize::DefaultIsZeroes for Boolean {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ConstIntSemiring, ensure_type_implements_trait};
+    use crate::{ConstIntSemiring, Wrapper, ensure_type_implements_trait};
     use alloc::{vec, vec::Vec};
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(Boolean, Wrapper);
         ensure_type_implements_trait!(Boolean, ConstIntSemiring);
     }
 
@@ -590,7 +607,7 @@ mod tests {
         assert_eq!(bool::from(Boolean::FALSE), false);
 
         // Methods
-        assert_eq!(Boolean::new(true).inner(), true);
+        assert_eq!(*Boolean::new(true).inner(), true);
         assert_eq!(Boolean::new(false).into_inner(), false);
         assert_eq!(Boolean::TRUE.to_u8(), 1);
         assert_eq!(Boolean::FALSE.to_u8(), 0);

--- a/src/semiring/boolean.rs
+++ b/src/semiring/boolean.rs
@@ -1,4 +1,4 @@
-use crate::{ConstSemiring, IntSemiring, Semiring, Wrapper, f2::F2};
+use crate::{IntSemiring, Wrapper, f2::F2};
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::Hash,
@@ -6,7 +6,10 @@ use core::{
     ops::{Add, AddAssign, Deref, Mul, MulAssign, Sub, SubAssign},
     str::FromStr,
 };
-use num_traits::{CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, One, Pow, Zero};
+use num_traits::{
+    Bounded, CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, FromBytes, One, Pow, ToBytes,
+    Zero,
+};
 
 #[cfg(feature = "rand")]
 use rand::{distr::StandardUniform, prelude::*};
@@ -393,11 +396,44 @@ impl Wrapper for Boolean {
 // Semiring
 //
 
-impl Semiring for Boolean {}
+impl Bounded for Boolean {
+    #[inline(always)]
+    fn min_value() -> Self {
+        Self::FALSE
+    }
 
-impl ConstSemiring for Boolean {
-    const MAX: Self = Self::TRUE;
-    const MIN: Self = Self::FALSE;
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::TRUE
+    }
+}
+
+impl ToBytes for Boolean {
+    type Bytes = [u8; 1];
+
+    #[inline(always)]
+    fn to_be_bytes(&self) -> Self::Bytes {
+        [self.to_u8()]
+    }
+
+    #[inline(always)]
+    fn to_le_bytes(&self) -> Self::Bytes {
+        [self.to_u8()]
+    }
+}
+
+impl FromBytes for Boolean {
+    type Bytes = [u8; 1];
+
+    #[inline(always)]
+    fn from_be_bytes(bytes: &Self::Bytes) -> Self {
+        Self::from_u8(bytes[0])
+    }
+
+    #[inline(always)]
+    fn from_le_bytes(bytes: &Self::Bytes) -> Self {
+        Self::from_u8(bytes[0])
+    }
 }
 
 impl IntSemiring for Boolean {

--- a/src/semiring/boolean.rs
+++ b/src/semiring/boolean.rs
@@ -460,6 +460,30 @@ impl Distribution<Boolean> for StandardUniform {
 }
 
 //
+// Serialization and Deserialization
+//
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Boolean {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        bool::deserialize(deserializer).map(Self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Boolean {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+//
 // Zeroize
 //
 

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boolean::Boolean, pow_via_repeated_squaring};
+use crate::{Wrapper, boolean::Boolean, pow_via_repeated_squaring};
 use alloc::boxed::Box;
 use core::{
     cmp::Ordering,
@@ -26,7 +26,7 @@ use rand::rand_core::TryRng;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct BoxedUint(crypto_bigint::BoxedUint);
+pub struct BoxedUint(pub crypto_bigint::BoxedUint);
 
 impl BoxedUint {
     /// Wraps a given value into this wrapper type
@@ -47,24 +47,6 @@ impl BoxedUint {
         // Safety: BoxedUint is #[repr(transparent)] and is guaranteed to have the
         // same memory layout as crypto_bigint::BoxedUint
         unsafe { &mut *(value as *mut crypto_bigint::BoxedUint as *mut Self) }
-    }
-
-    /// Get a reference to the wrapped value
-    #[inline(always)]
-    pub fn inner(&self) -> &crypto_bigint::BoxedUint {
-        &self.0
-    }
-
-    /// Get a mutable reference to the wrapped value
-    #[inline(always)]
-    pub fn inner_mut(&mut self) -> &mut crypto_bigint::BoxedUint {
-        &mut self.0
-    }
-
-    /// Get the wrapped value, consuming self
-    #[inline(always)]
-    pub fn into_inner(self) -> crypto_bigint::BoxedUint {
-        self.0
     }
 
     /// See [crypto_bigint::BoxedUint::from_words]
@@ -655,6 +637,34 @@ impl<const LIMBS: usize> From<&crypto_bigint::Uint<LIMBS>> for BoxedUint {
 }
 
 //
+// Wrapper
+//
+
+impl Wrapper for BoxedUint {
+    type Inner = crypto_bigint::BoxedUint;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
+    }
+}
+
+//
 // Semiring
 //
 
@@ -808,6 +818,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(BoxedUint, Wrapper);
         ensure_type_implements_trait!(BoxedUint, FixedSemiring);
         ensure_type_implements_trait!(BoxedUint, IntSemiring);
         ensure_type_implements_trait!(BoxedUint, IntSemiringWithShifts);

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -690,8 +690,6 @@ impl Wrapper for BoxedUint {
 // Semiring
 //
 
-impl Semiring for BoxedUint {}
-
 impl IntSemiring for BoxedUint {
     #[inline(always)]
     fn is_odd(&self) -> bool {
@@ -841,7 +839,7 @@ mod tests {
     #[test]
     fn ensure_traits() {
         ensure_type_implements_trait!(BoxedUint, Wrapper);
-        ensure_type_implements_trait!(BoxedUint, FixedSemiring);
+        ensure_type_implements_trait!(BoxedUint, Semiring);
         ensure_type_implements_trait!(BoxedUint, IntSemiring);
         ensure_type_implements_trait!(BoxedUint, IntSemiringWithShifts);
     }

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Wrapper, boolean::Boolean, pow_via_repeated_squaring};
+use crate::{Wrapper, boolean::Boolean, helpers::pow_via_repeated_squaring};
 use alloc::boxed::Box;
 use core::{
     cmp::Ordering,

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -12,7 +12,9 @@ use core::{
     },
     str::FromStr,
 };
-use crypto_bigint::{BitOps, DivVartime, Integer, Limb, RandomBitsError, Resize, Word};
+use crypto_bigint::{
+    BitOps, ConcatenatingMul, DivVartime, Integer, Limb, RandomBitsError, Resize, UintRef, Word,
+};
 use num_traits::{
     CheckedAdd, CheckedMul, CheckedRem, CheckedSub, One, Pow, WrappingAdd, WrappingMul,
     WrappingSub, Zero,
@@ -47,10 +49,16 @@ impl BoxedUint {
         unsafe { &mut *(value as *mut crypto_bigint::BoxedUint as *mut Self) }
     }
 
-    /// Get the reference to the wrapped value
+    /// Get a reference to the wrapped value
     #[inline(always)]
     pub fn inner(&self) -> &crypto_bigint::BoxedUint {
         &self.0
+    }
+
+    /// Get a mutable reference to the wrapped value
+    #[inline(always)]
+    pub fn inner_mut(&mut self) -> &mut crypto_bigint::BoxedUint {
+        &mut self.0
     }
 
     /// Get the wrapped value, consuming self
@@ -154,11 +162,99 @@ impl BoxedUint {
             at_least_bits_precision,
         ))
     }
+
+    /// See [`crypto_bigint::BoxedUint::concatenating_mul`]
+    pub fn concatenating_mul(&self, rhs: &[Limb]) -> Self {
+        let rhs = UintRef::new(rhs);
+        self.0.concatenating_mul(rhs).into()
+    }
+
+    /// Get the least significant 64-bits.
+    pub fn lowest_u64(&self) -> u64 {
+        #[cfg(target_pointer_width = "32")]
+        let res = {
+            debug_assert!(self.nlimbs() >= 1);
+            let mut ret = self.limbs[0].0 as u64;
+
+            if self.nlimbs() >= 2 {
+                ret |= (self.limbs[1].0 as u64) << 32;
+            }
+
+            ret
+        };
+
+        #[cfg(target_pointer_width = "64")]
+        let res = self.as_limbs()[0].0;
+
+        #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+        let res = panic!("Unsupported target pointer width");
+
+        res
+    }
+
+    /// See [`crypto_bigint::BoxedUint::conditional_wrapping_neg_assign`]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn conditional_wrapping_neg_assign(&mut self, choice: crypto_bigint::Choice) {
+        use crypto_bigint::CtAssign;
+        let mut carry = 1;
+
+        for i in 0..self.nlimbs() {
+            let r = crypto_bigint::WideWord::from(!self.as_limbs()[i].0) + carry;
+            self.as_mut_limbs()[i].ct_assign(&Limb(r as Word), choice);
+            carry = r >> Limb::BITS;
+        }
+    }
+
+    /// See [`crypto_bigint::BoxedUint::borrowing_sub_assign`]
+    #[inline(always)]
+    pub fn borrowing_sub_assign(&mut self, rhs: &[Limb], borrow: Limb) -> Limb {
+        assert!(rhs.len() <= self.nlimbs());
+
+        let mut carry = borrow;
+        let self_limbs = self.as_mut_limbs();
+        for i in 0..self_limbs.len() {
+            let &b = rhs.get(i).unwrap_or(&Limb::ZERO);
+            (self_limbs[i], carry) = Limb::borrowing_sub(self_limbs[i], b, carry);
+        }
+        carry
+    }
+
+    /// See [`crypto_bigint::BoxedUint::sub_assign_mod_with_carry`]
+    #[inline(always)]
+    pub fn sub_assign_mod_with_carry(&mut self, carry: Limb, rhs: &BoxedUint, p: &BoxedUint) {
+        debug_assert!(carry.0 <= 1);
+
+        let borrow = self.borrowing_sub_assign(rhs.as_limbs(), Limb::ZERO);
+
+        // The new `borrow = Word::MAX` iff `carry == 0` and `borrow == Word::MAX`.
+        let mask = carry.wrapping_neg().not().bitand(borrow);
+
+        // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
+        // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
+        // modulus.
+        let _ = UintRef::new_mut(self.as_mut_limbs())
+            .conditional_add_assign(UintRef::new(rhs.as_limbs()), Limb::ZERO, !mask.is_zero())
+            .lsb_to_choice();
+    }
 }
 
 //
 // Core traits
 //
+
+impl AsRef<UintRef> for BoxedUint {
+    #[inline(always)]
+    fn as_ref(&self) -> &UintRef {
+        self.inner().as_ref()
+    }
+}
+
+impl AsMut<UintRef> for BoxedUint {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut UintRef {
+        self.inner_mut().as_mut()
+    }
+}
 
 impl Debug for BoxedUint {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
@@ -495,6 +591,20 @@ impl From<BoxedUint> for crypto_bigint::BoxedUint {
     }
 }
 
+impl<'a> From<&'a crypto_bigint::BoxedUint> for &'a BoxedUint {
+    #[inline(always)]
+    fn from(value: &'a crypto_bigint::BoxedUint) -> Self {
+        BoxedUint::new_ref(value)
+    }
+}
+
+impl<'a> From<&'a BoxedUint> for &'a crypto_bigint::BoxedUint {
+    #[inline(always)]
+    fn from(value: &'a BoxedUint) -> Self {
+        &value.0
+    }
+}
+
 impl From<bool> for BoxedUint {
     #[inline(always)]
     fn from(value: bool) -> Self {
@@ -551,10 +661,12 @@ impl<const LIMBS: usize> From<&crypto_bigint::Uint<LIMBS>> for BoxedUint {
 impl Semiring for BoxedUint {}
 
 impl IntSemiring for BoxedUint {
+    #[inline(always)]
     fn is_odd(&self) -> bool {
         self.0.is_odd().into()
     }
 
+    #[inline(always)]
     fn is_even(&self) -> bool {
         self.0.is_even().into()
     }
@@ -695,7 +807,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         ensure_type_implements_trait!(BoxedUint, FixedSemiring);
         ensure_type_implements_trait!(BoxedUint, IntSemiring);
         ensure_type_implements_trait!(BoxedUint, IntSemiringWithShifts);

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -24,7 +24,7 @@ use pastey::paste;
 #[cfg(feature = "rand")]
 use rand::rand_core::TryRng;
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct BoxedUint(pub crypto_bigint::BoxedUint);
 
@@ -102,12 +102,6 @@ impl BoxedUint {
     #[inline(always)]
     pub fn resize(&self, at_least_bits_precision: u32) -> Self {
         Self((&self.0).resize_unchecked(at_least_bits_precision))
-    }
-
-    /// See [crypto_bigint::BoxedUint::cmp_vartime]
-    #[inline(always)]
-    pub fn cmp_vartime(&self, rhs: &Self) -> Ordering {
-        self.0.cmp_vartime(&rhs.0)
     }
 
     /// See [crypto_bigint::BoxedUint::from_be_hex]
@@ -269,6 +263,21 @@ impl Default for BoxedUint {
     }
 }
 
+impl PartialOrd for BoxedUint {
+    #[inline(always)]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Implemented manually to use `cmp_vartime`
+impl Ord for BoxedUint {
+    #[inline(always)]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp_vartime(&other.0)
+    }
+}
+
 impl LowerHex for BoxedUint {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         LowerHex::fmt(&self.0, f)
@@ -283,6 +292,7 @@ impl UpperHex for BoxedUint {
 
 impl Hash for BoxedUint {
     #[allow(clippy::arithmetic_side_effects)]
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Equality is by numeric value and ignores high zero limbs, so we must
         // hash only the significant limbs to keep `Hash` consistent with `Eq`.
@@ -1232,14 +1242,14 @@ mod tests {
     }
 
     #[test]
-    fn cmp_vartime() {
+    fn cmp() {
         let a = BoxedUint::from(10_u64);
         let b = BoxedUint::from(20_u64);
         let c = BoxedUint::from(10_u64);
 
-        assert_eq!(a.cmp_vartime(&b), Ordering::Less);
-        assert_eq!(b.cmp_vartime(&a), Ordering::Greater);
-        assert_eq!(a.cmp_vartime(&c), Ordering::Equal);
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&a), Ordering::Greater);
+        assert_eq!(a.cmp(&c), Ordering::Equal);
     }
 
     #[test]

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -175,7 +175,7 @@ impl BoxedUint {
     }
 
     /// See [`crypto_bigint::BoxedUint::conditional_wrapping_neg_assign`]
-    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_truncation, clippy::arithmetic_side_effects)]
     pub fn conditional_wrapping_neg_assign(&mut self, choice: crypto_bigint::Choice) {
         use crypto_bigint::CtAssign;
         let mut carry = 1;
@@ -189,11 +189,13 @@ impl BoxedUint {
 
     /// See [`crypto_bigint::BoxedUint::borrowing_sub_assign`]
     #[inline(always)]
+    #[allow(clippy::needless_range_loop)]
     pub fn borrowing_sub_assign(&mut self, rhs: &[Limb], borrow: Limb) -> Limb {
         assert!(rhs.len() <= self.nlimbs());
 
         let mut carry = borrow;
         let self_limbs = self.as_mut_limbs();
+
         for i in 0..self_limbs.len() {
             let &b = rhs.get(i).unwrap_or(&Limb::ZERO);
             (self_limbs[i], carry) = Limb::borrowing_sub(self_limbs[i], b, carry);
@@ -215,7 +217,7 @@ impl BoxedUint {
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
         // modulus.
         let _ = UintRef::new_mut(self.as_mut_limbs())
-            .conditional_add_assign(UintRef::new(rhs.as_limbs()), Limb::ZERO, !mask.is_zero())
+            .conditional_add_assign(UintRef::new(p.as_limbs()), Limb::ZERO, !mask.is_zero())
             .lsb_to_choice();
     }
 }

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -56,32 +56,37 @@ impl BoxedUint {
     }
 
     /// See [crypto_bigint::BoxedUint::to_words]
-    #[inline]
+    #[inline(always)]
     pub fn to_words(self) -> Box<[Word]> {
         self.0.to_words()
     }
 
     /// See [crypto_bigint::BoxedUint::as_words]
+    #[inline(always)]
     pub fn as_words(&self) -> &[Word] {
         self.0.as_words()
     }
 
     /// See [crypto_bigint::BoxedUint::as_mut_words]
+    #[inline(always)]
     pub fn as_mut_words(&mut self) -> &mut [Word] {
         self.0.as_mut_words()
     }
 
     /// See [crypto_bigint::BoxedUint::as_limbs]
+    #[inline(always)]
     pub fn as_limbs(&self) -> &[Limb] {
         self.0.as_limbs()
     }
 
     /// See [crypto_bigint::BoxedUint::as_mut_limbs]
+    #[inline(always)]
     pub fn as_mut_limbs(&mut self) -> &mut [Limb] {
         self.0.as_mut_limbs()
     }
 
     /// See [crypto_bigint::BoxedUint::to_limbs]
+    #[inline(always)]
     pub fn to_limbs(self) -> Box<[Limb]> {
         self.0.to_limbs()
     }
@@ -100,6 +105,7 @@ impl BoxedUint {
     }
 
     /// See [crypto_bigint::BoxedUint::cmp_vartime]
+    #[inline(always)]
     pub fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         self.0.cmp_vartime(&rhs.0)
     }
@@ -112,21 +118,25 @@ impl BoxedUint {
     }
 
     /// See [`crypto_bigint::BoxedUint::bits`]
+    #[inline(always)]
     pub fn bits(&self) -> u32 {
         self.0.bits()
     }
 
     /// See [`crypto_bigint::BoxedUint::bits_precision`]
+    #[inline(always)]
     pub fn bits_precision(&self) -> u32 {
         self.0.bits_precision()
     }
 
     /// See [`crypto_bigint::BoxedUint::bytes_precision`]
+    #[inline(always)]
     pub fn bytes_precision(&self) -> usize {
         self.0.bytes_precision()
     }
 
     /// See [`crypto_bigint::BoxedUint::nlimbs`]
+    #[inline(always)]
     pub fn nlimbs(&self) -> usize {
         self.0.nlimbs()
     }
@@ -156,10 +166,10 @@ impl BoxedUint {
         #[cfg(target_pointer_width = "32")]
         let res = {
             debug_assert!(self.nlimbs() >= 1);
-            let mut ret = self.limbs[0].0 as u64;
+            let mut ret = self.as_limbs()[0].0 as u64;
 
             if self.nlimbs() >= 2 {
-                ret |= (self.limbs[1].0 as u64) << 32;
+                ret |= (self.as_limbs()[1].0 as u64) << 32;
             }
 
             ret

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::{Wrapper, boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring};
+use crate::{
+    Wrapper, boolean::Boolean, crypto_bigint_int::Int, helpers::pow_via_repeated_squaring,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -21,7 +21,7 @@ use pastey::paste;
 #[cfg(feature = "rand")]
 use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Uint<const LIMBS: usize>(pub crypto_bigint::Uint<LIMBS>);
 
@@ -94,11 +94,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             None => None,
             Some(inner) => Some(Uint(inner)),
         }
-    }
-
-    /// See [crypto_bigint::Uint::cmp_vartime]
-    pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
-        self.0.cmp_vartime(&rhs.0)
     }
 
     /// See [crypto_bigint::Uint::as_int]
@@ -176,7 +171,23 @@ impl<const LIMBS: usize> Default for Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> PartialOrd for Uint<LIMBS> {
+    #[inline(always)]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Implemented manually to use `cmp_vartime`
+impl<const LIMBS: usize> Ord for Uint<LIMBS> {
+    #[inline(always)]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp_vartime(&other.0)
+    }
+}
+
 impl<const LIMBS: usize> LowerHex for Uint<LIMBS> {
+    #[inline(always)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         LowerHex::fmt(&self.0, f)
     }
@@ -189,6 +200,7 @@ impl<const LIMBS: usize> UpperHex for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> Hash for Uint<LIMBS> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state)
     }
@@ -1174,14 +1186,14 @@ mod tests {
     }
 
     #[test]
-    fn cmp_vartime() {
+    fn cmp() {
         let a = Uint4::from(10_u64);
         let b = Uint4::from(20_u64);
         let c = Uint4::from(10_u64);
 
-        assert_eq!(a.cmp_vartime(&b), Ordering::Less);
-        assert_eq!(b.cmp_vartime(&a), Ordering::Greater);
-        assert_eq!(a.cmp_vartime(&c), Ordering::Equal);
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&a), Ordering::Greater);
+        assert_eq!(a.cmp(&c), Ordering::Equal);
     }
 
     #[test]

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::{
-    WORD_FACTOR, Wrapper, boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring,
-};
+use crate::{Wrapper, boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -723,6 +721,7 @@ impl<const LIMBS: usize> crypto_bigint::Constants for Uint<LIMBS> {
 // Predefined uints of various sizes for convenience
 //
 
+use crate::helpers::crypto_bigint::WORD_FACTOR;
 pub type U64 = Uint<{ WORD_FACTOR }>;
 pub type U128 = Uint<{ 2 * WORD_FACTOR }>;
 pub type U192 = Uint<{ 3 * WORD_FACTOR }>;

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::{WORD_FACTOR, boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring};
+use crate::{
+    WORD_FACTOR, Wrapper, boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -23,7 +25,7 @@ use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct Uint<const LIMBS: usize>(crypto_bigint::Uint<LIMBS>);
+pub struct Uint<const LIMBS: usize>(pub crypto_bigint::Uint<LIMBS>);
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Wraps a given value into this wrapper type
@@ -44,24 +46,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Safety: Uint<LIMBS> is #[repr(transparent)] and is guaranteed to have the
         // same memory layout as crypto_bigint::Uint
         unsafe { &mut *(value as *mut crypto_bigint::Uint<LIMBS> as *mut Self) }
-    }
-
-    /// Get a reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner(&self) -> &crypto_bigint::Uint<LIMBS> {
-        &self.0
-    }
-
-    /// Get a mutable reference to the wrapped value
-    #[inline(always)]
-    pub const fn inner_mut(&mut self) -> &mut crypto_bigint::Uint<LIMBS> {
-        &mut self.0
-    }
-
-    /// Get the wrapped value, consuming self
-    #[inline(always)]
-    pub const fn into_inner(self) -> crypto_bigint::Uint<LIMBS> {
-        self.0
     }
 
     /// See [crypto_bigint::Uint::from_words]
@@ -590,6 +574,34 @@ impl<const LIMBS: usize, const LIMBS2: usize> TryFrom<&crypto_bigint::Uint<LIMBS
 }
 
 //
+// Wrapper
+//
+
+impl<const LIMBS: usize> Wrapper for Uint<LIMBS> {
+    type Inner = crypto_bigint::Uint<LIMBS>;
+
+    #[inline(always)]
+    fn inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    #[inline(always)]
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    #[inline(always)]
+    fn new_unchecked(inner: Self::Inner) -> Self {
+        Self(inner)
+    }
+}
+
+//
 // Semiring
 //
 
@@ -759,6 +771,7 @@ mod tests {
 
     #[test]
     fn ensure_traits() {
+        ensure_type_implements_trait!(Uint4, Wrapper);
         ensure_type_implements_trait!(Uint4, ConstIntSemiring);
         ensure_type_implements_trait!(Uint4, IntSemiringWithShifts);
     }

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring};
+use crate::{WORD_FACTOR, boolean::Boolean, crypto_bigint_int::Int, pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -11,7 +11,7 @@ use core::{
     },
     str::FromStr,
 };
-use crypto_bigint::{DivVartime, Integer, Limb, Word};
+use crypto_bigint::{DivVartime, Integer, Limb, UintRef, Word};
 use num_traits::{
     CheckedAdd, CheckedMul, CheckedRem, CheckedSub, ConstOne, ConstZero, One, Pow, WrappingAdd,
     WrappingMul, WrappingSub, Zero,
@@ -46,10 +46,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         unsafe { &mut *(value as *mut crypto_bigint::Uint<LIMBS> as *mut Self) }
     }
 
-    /// Get the reference to the wrapped value
+    /// Get a reference to the wrapped value
     #[inline(always)]
     pub const fn inner(&self) -> &crypto_bigint::Uint<LIMBS> {
         &self.0
+    }
+
+    /// Get a mutable reference to the wrapped value
+    #[inline(always)]
+    pub const fn inner_mut(&mut self) -> &mut crypto_bigint::Uint<LIMBS> {
+        &mut self.0
     }
 
     /// Get the wrapped value, consuming self
@@ -154,6 +160,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 //
 // Core traits
 //
+
+impl<const LIMBS: usize> AsRef<UintRef> for Uint<LIMBS> {
+    #[inline(always)]
+    fn as_ref(&self) -> &UintRef {
+        self.inner().as_ref()
+    }
+}
+
+impl<const LIMBS: usize> AsMut<UintRef> for Uint<LIMBS> {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut UintRef {
+        self.inner_mut().as_mut()
+    }
+}
 
 impl<const LIMBS: usize> Debug for Uint<LIMBS> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
@@ -499,6 +519,20 @@ impl<const LIMBS: usize> From<Uint<LIMBS>> for crypto_bigint::Uint<LIMBS> {
     }
 }
 
+impl<'a, const LIMBS: usize> From<&'a crypto_bigint::Uint<LIMBS>> for &'a Uint<LIMBS> {
+    #[inline(always)]
+    fn from(value: &'a crypto_bigint::Uint<LIMBS>) -> Self {
+        Uint::new_ref(value)
+    }
+}
+
+impl<'a, const LIMBS: usize> From<&'a Uint<LIMBS>> for &'a crypto_bigint::Uint<LIMBS> {
+    #[inline(always)]
+    fn from(value: &'a Uint<LIMBS>) -> Self {
+        &value.0
+    }
+}
+
 impl<const LIMBS: usize> From<bool> for Uint<LIMBS> {
     #[inline(always)]
     fn from(value: bool) -> Self {
@@ -567,10 +601,12 @@ impl<const LIMBS: usize> ConstSemiring for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> IntSemiring for Uint<LIMBS> {
+    #[inline(always)]
     fn is_odd(&self) -> bool {
         self.0.is_odd().into()
     }
 
+    #[inline(always)]
     fn is_even(&self) -> bool {
         self.0.is_even().into()
     }
@@ -671,6 +707,40 @@ impl<const LIMBS: usize> crypto_bigint::Constants for Uint<LIMBS> {
     const MAX: Self = ConstSemiring::MAX;
 }
 
+//
+// Predefined uints of various sizes for convenience
+//
+
+pub type U64 = Uint<{ 1 * WORD_FACTOR }>;
+pub type U128 = Uint<{ 2 * WORD_FACTOR }>;
+pub type U192 = Uint<{ 3 * WORD_FACTOR }>;
+pub type U256 = Uint<{ 4 * WORD_FACTOR }>;
+pub type U320 = Uint<{ 5 * WORD_FACTOR }>;
+pub type U384 = Uint<{ 6 * WORD_FACTOR }>;
+pub type U448 = Uint<{ 7 * WORD_FACTOR }>;
+pub type U512 = Uint<{ 8 * WORD_FACTOR }>;
+pub type U576 = Uint<{ 9 * WORD_FACTOR }>;
+pub type U640 = Uint<{ 10 * WORD_FACTOR }>;
+pub type U704 = Uint<{ 11 * WORD_FACTOR }>;
+pub type U768 = Uint<{ 12 * WORD_FACTOR }>;
+pub type U832 = Uint<{ 13 * WORD_FACTOR }>;
+pub type U896 = Uint<{ 14 * WORD_FACTOR }>;
+pub type U960 = Uint<{ 15 * WORD_FACTOR }>;
+pub type U1024 = Uint<{ 16 * WORD_FACTOR }>;
+pub type U1280 = Uint<{ 20 * WORD_FACTOR }>;
+pub type U1536 = Uint<{ 24 * WORD_FACTOR }>;
+pub type U1792 = Uint<{ 28 * WORD_FACTOR }>;
+pub type U2048 = Uint<{ 32 * WORD_FACTOR }>;
+pub type U3072 = Uint<{ 48 * WORD_FACTOR }>;
+pub type U3584 = Uint<{ 56 * WORD_FACTOR }>;
+pub type U4096 = Uint<{ 64 * WORD_FACTOR }>;
+pub type U4224 = Uint<{ 66 * WORD_FACTOR }>;
+pub type U4352 = Uint<{ 68 * WORD_FACTOR }>;
+pub type U6144 = Uint<{ 96 * WORD_FACTOR }>;
+pub type U8192 = Uint<{ 128 * WORD_FACTOR }>;
+pub type U16384 = Uint<{ 256 * WORD_FACTOR }>;
+pub type U32768 = Uint<{ 512 * WORD_FACTOR }>;
+
 #[allow(clippy::arithmetic_side_effects, clippy::cast_lossless)]
 #[cfg(test)]
 mod tests {
@@ -688,7 +758,7 @@ mod tests {
     type Uint4 = Uint<{ WORD_FACTOR * 4 }>;
 
     #[test]
-    fn ensure_blanket_traits() {
+    fn ensure_traits() {
         ensure_type_implements_trait!(Uint4, ConstIntSemiring);
         ensure_type_implements_trait!(Uint4, IntSemiringWithShifts);
     }

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -723,7 +723,7 @@ impl<const LIMBS: usize> crypto_bigint::Constants for Uint<LIMBS> {
 // Predefined uints of various sizes for convenience
 //
 
-pub type U64 = Uint<{ 1 * WORD_FACTOR }>;
+pub type U64 = Uint<{ WORD_FACTOR }>;
 pub type U128 = Uint<{ 2 * WORD_FACTOR }>;
 pub type U192 = Uint<{ 3 * WORD_FACTOR }>;
 pub type U256 = Uint<{ 4 * WORD_FACTOR }>;

--- a/src/semiring/crypto_bigint_uint.rs
+++ b/src/semiring/crypto_bigint_uint.rs
@@ -26,6 +26,8 @@ use rand::{distr::StandardUniform, prelude::*, rand_core::TryRng};
 pub struct Uint<const LIMBS: usize>(pub crypto_bigint::Uint<LIMBS>);
 
 impl<const LIMBS: usize> Uint<LIMBS> {
+    pub const MAX: Self = Self(crypto_bigint::Uint::MAX);
+
     /// Wraps a given value into this wrapper type
     #[inline(always)]
     pub const fn new(value: crypto_bigint::Uint<LIMBS>) -> Self {
@@ -615,11 +617,16 @@ impl<const LIMBS: usize> Wrapper for Uint<LIMBS> {
 // Semiring
 //
 
-impl<const LIMBS: usize> Semiring for Uint<LIMBS> {}
+impl<const LIMBS: usize> Bounded for Uint<LIMBS> {
+    #[inline(always)]
+    fn min_value() -> Self {
+        Self::ZERO
+    }
 
-impl<const LIMBS: usize> ConstSemiring for Uint<LIMBS> {
-    const MAX: Self = Self(crypto_bigint::Uint::MAX);
-    const MIN: Self = Self(crypto_bigint::Uint::ZERO);
+    #[inline(always)]
+    fn max_value() -> Self {
+        Self::MAX
+    }
 }
 
 impl<const LIMBS: usize> IntSemiring for Uint<LIMBS> {
@@ -726,7 +733,7 @@ impl<const LIMBS: usize> crypto_bigint::Bounded for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> crypto_bigint::Constants for Uint<LIMBS> {
-    const MAX: Self = ConstSemiring::MAX;
+    const MAX: Self = Self::MAX;
 }
 
 //
@@ -839,7 +846,7 @@ mod tests {
 
         // MIN and MAX
         assert_eq!(Uint4::MAX.checked_add(&One::one()), None);
-        assert_eq!(Uint4::MIN.checked_sub(&One::one()), None);
+        assert_eq!(Uint4::ZERO.checked_sub(&One::one()), None);
     }
 
     #[allow(clippy::op_ref)]


### PR DESCRIPTION
This PR fully reworks the set (`Semiring`/`Ring`/`Field`) hierarchy, so that field with elements no longer have to carry a copy of field parameters with them. Currently we still only have support for base fields, but extension fields could be integrated seamlessly.

We split sets into two categories:
* Static, where metadata is stored in a centralized way, thus making field elements self-sufficient for operations (`a + b`).
* Dynamic/general, where the only the `*Config` can perform operations on field elements (`cfg.add(&a, &b)`)
* `FixedConfig` is a bridge between them, making `*Config` approach truly general.
* Also, each field now has an associated integer (semiring) type that is used for exponent, and (for base fields) for modulus and lifting. That integer has to be projectable onto a field.

Please see crate-level and module-level docs for more details.

Fixed hierarchy now looks like this:
```
Semiring < Ring < Field < BaseField
```
(with `ConstBaseField` being a special case of `BaseField`)

For general fields:
```
SemiringConfig < RingConfig < FieldConfig < BaseFieldConfig
```

# Implementation

To implement `FieldConfig` for currently supported fields with dynamic moduli (`crypto_bigint_monty` and `crypto_bigint_boxed_monty`), we had to largely replicate what library was doing by dismantling `FixedMontyForm` and `BoxedMontyForm` and copy-pasting a lot of library code into a helper module. This is an unfortunate consequence of library inner helpers being private.