### PR TITLE
Fix: feature gate config and add feature matrix in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,3 +19,68 @@ jobs:
       run: cargo test --workspace --all-features --verbose --no-run
     - name: Run tests
       run: cargo test --workspace --all-features --verbose
+
+  # `--all-features` unifies features across the dependency graph, so it hides
+  # missing feature gates. Test each combination on its own to catch them.
+  feature-matrix:
+    name: Test ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    env:
+      # A missing feature gate shows up as an unused import long before it
+      # becomes a build failure, so warnings have to be fatal here.
+      RUSTFLAGS: "-Dwarnings"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: no-default-features
+            args: --no-default-features
+          - name: std
+            args: --no-default-features --features std
+          - name: ark_std
+            args: --no-default-features --features ark_std
+          - name: num_bigint
+            args: --no-default-features --features num_bigint
+          - name: rand
+            args: --no-default-features --features rand
+          - name: serde
+            args: --no-default-features --features serde
+          - name: zeroize
+            args: --no-default-features --features zeroize
+          - name: zerocopy
+            args: --no-default-features --features zerocopy
+          - name: parallel
+            args: --no-default-features --features parallel
+          - name: crypto_bigint
+            args: --no-default-features --features crypto_bigint
+          - name: ark_ff
+            args: --no-default-features --features ark_ff
+          # Backend x utility pairs. Utility features gate items *inside* the
+          # backend modules, so this intersection is the only place that code
+          # is compiled -- neither single-feature build reaches it.
+          - name: crypto_bigint,rand
+            args: --no-default-features --features crypto_bigint,rand
+          - name: crypto_bigint,serde
+            args: --no-default-features --features crypto_bigint,serde
+          - name: crypto_bigint,zeroize
+            args: --no-default-features --features crypto_bigint,zeroize
+          - name: crypto_bigint,zerocopy
+            args: --no-default-features --features crypto_bigint,zerocopy
+          - name: ark_ff,rand
+            args: --no-default-features --features ark_ff,rand
+          - name: ark_ff,serde
+            args: --no-default-features --features ark_ff,serde
+          - name: ark_ff,zeroize
+            args: --no-default-features --features ark_ff,zeroize
+          - name: ark_ff,zerocopy
+            args: --no-default-features --features ark_ff,zerocopy
+          - name: ark_ff,crypto_bigint
+            args: --no-default-features --features ark_ff,crypto_bigint
+          - name: ark_ff,std
+            args: --no-default-features --features ark_ff,std
+          - name: all-features
+            args: --all-features
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: cargo test ${{ matrix.args }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,12 @@ num-bigint = { version = "0.4", default-features = false, optional = true }
 # Optional utility for which implementations are provided
 rand = { workspace = true, optional = true }
 rayon = { version = "1", optional = true }
-serde = { version = "1", default-features = false, optional = true }
+serde = { version = "1", default-features = false, features = ["alloc"], optional = true }
 zeroize = { version = "1", features = ["derive"], optional = true }
 zerocopy = { version = "0.8", default-features = false, optional = true }
 zerocopy-derive = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]
-crypto-primitives = { workspace = true, features = ["crypto_bigint"] }
 criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true, features = ["std_rng"] }
@@ -43,12 +42,12 @@ rand = { workspace = true, features = ["std_rng"] }
 default = ["std"]
 
 parallel = ["dep:rayon"]
-rand = ["dep:rand", "crypto-bigint/rand_core"]
-serde = ["dep:serde", "crypto-bigint/serde"]
-zeroize = ["dep:zeroize", "crypto-bigint/zeroize"]
+rand = ["dep:rand", "crypto-bigint?/rand_core"]
+serde = ["dep:serde", "crypto-bigint?/serde"]
+zeroize = ["dep:zeroize", "crypto-bigint?/zeroize"]
 zerocopy = ["dep:zerocopy", "dep:zerocopy-derive"]
 
-std = ["num-traits/std", "ark-std/std", "ark-ff/std", "serde/std", "rand/std", "zeroize/std", "zerocopy/std"]
+std = ["num-traits/std", "ark-std?/std", "ark-ff?/std", "serde?/std", "rand?/std", "zeroize?/std", "zerocopy?/std"]
 ark_std = ["dep:ark-std"]
 ark_ff = ["ark_std", "num_bigint", "zeroize", "dep:ark-ff", "dep:ark-serialize"]
 crypto_bigint = ["dep:crypto-bigint", "crypto-bigint/alloc"]
@@ -57,14 +56,17 @@ num_bigint = ["dep:num-bigint"]
 [[bench]]
 name = "boxed_monty_field_benches"
 harness = false
+required-features = ["crypto_bigint"]
 
 [[bench]]
 name = "const_monty_field_benches"
 harness = false
+required-features = ["crypto_bigint"]
 
 [[bench]]
 name = "monty_field_benches"
 harness = false
+required-features = ["crypto_bigint"]
 
 #
 # Workspace configuration

--- a/proc-macros/src/infallible_checked_op.rs
+++ b/proc-macros/src/infallible_checked_op.rs
@@ -3,7 +3,6 @@ use syn::{
     punctuated::Punctuated, spanned::Spanned, token::Comma,
 };
 
-#[derive(Debug)]
 pub(super) enum Op {
     Unary {
         trait_path: Path,

--- a/src/field.rs
+++ b/src/field.rs
@@ -41,14 +41,14 @@ pub mod crypto_bigint_monty;
 pub mod f2;
 
 use crate::{
-    ConstRing, FixedConfig, IntSemiring, Ring, RingConfig, SemiringConfig, SetConfig, SetElement,
+    ConstRing, FixedConfig, IntSemiring, Ring, RingConfig, SetConfig, SetElement,
     helpers::{define_blanket_trait, delegate_to_ref_binary},
 };
 use core::{
     fmt::Debug,
-    ops::{Div, DivAssign, Neg},
+    ops::{Div, DivAssign},
 };
-use num_traits::{Bounded, Inv, Pow, Zero};
+use num_traits::{Bounded, Inv, Pow};
 use pastey::paste;
 use thiserror::Error;
 

--- a/src/field/ark_ff_field.rs
+++ b/src/field/ark_ff_field.rs
@@ -8,13 +8,14 @@ use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, Flags, Read, SerializationError, Valid, Validate, Write,
 };
+use ark_std::UniformRand;
 #[cfg(feature = "rand")]
-use ark_std::{UniformRand, rand::prelude::*};
+use ark_std::rand::prelude::*;
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     str::FromStr,
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
@@ -538,7 +539,6 @@ impl<F: ArkWrappedPrimeField> Distribution<ArkField<F>> for StandardUniform {
     }
 }
 
-#[cfg(feature = "rand")]
 impl<F: ArkWrappedPrimeField> UniformRand for ArkField<F> {
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         Self(F::rand(rng))

--- a/src/field/ark_ff_fp.rs
+++ b/src/field/ark_ff_fp.rs
@@ -9,14 +9,15 @@ use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, Flags, Read, SerializationError, Valid, Validate, Write,
 };
+use ark_std::UniformRand;
 #[cfg(feature = "rand")]
-use ark_std::{UniformRand, rand::prelude::*};
+use ark_std::rand::prelude::*;
 use core::{
     cmp::Ordering,
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Deref, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Deref, Mul, MulAssign, Neg, Sub, SubAssign},
     str::FromStr,
 };
 use crypto_primitives_proc_macros::InfallibleCheckedOp;
@@ -578,7 +579,6 @@ impl<P: FpConfig<N>, const N: usize> Distribution<Fp<P, N>> for StandardUniform 
     }
 }
 
-#[cfg(feature = "rand")]
 impl<P: FpConfig<N>, const N: usize> UniformRand for Fp<P, N> {
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         Self(ArkWrappedFp::rand(rng))

--- a/src/field/crypto_bigint_boxed_monty.rs
+++ b/src/field/crypto_bigint_boxed_monty.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::{
-    IntSemiring, IntSemiringConfig, LiftElementWithConfig, Wrapper, boolean::Boolean,
-    crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
-    helpers::crypto_bigint as helpers,
+    IntSemiring, IntSemiringConfig, LiftElementWithConfig, SemiringConfig, Wrapper,
+    boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int,
+    crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
 };
 use alloc::borrow::Cow;
 use core::{
@@ -13,7 +13,7 @@ use crypto_bigint::{
     MontyForm, Odd,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
-use num_traits::{One, Signed};
+use num_traits::{One, Signed, Zero};
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;
 #[cfg(feature = "zeroize")]

--- a/src/field/crypto_bigint_const_monty.rs
+++ b/src/field/crypto_bigint_const_monty.rs
@@ -8,7 +8,7 @@ use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, DivAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     str::FromStr,
 };
 use crypto_bigint::{

--- a/src/field/crypto_bigint_monty.rs
+++ b/src/field/crypto_bigint_monty.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::{
-    IntSemiring, IntSemiringConfig, LiftElementWithConfig, Wrapper, boolean::Boolean,
-    crypto_bigint_int::Int, crypto_bigint_uint::Uint, helpers::crypto_bigint as helpers,
+    IntSemiring, IntSemiringConfig, LiftElementWithConfig, SemiringConfig, Wrapper,
+    boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    helpers::crypto_bigint as helpers,
 };
 use core::{
     cmp::Ordering,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -17,6 +17,7 @@ macro_rules! define_blanket_trait {
 pub(crate) use define_blanket_trait;
 
 /// Implement exponentiation using repeated squaring
+#[cfg(any(feature = "ark_ff", feature = "crypto_bigint"))]
 macro_rules! pow_via_repeated_squaring {
     ($self:expr, $rhs:expr, $one:expr) => {{
         if $rhs == 0 {
@@ -42,6 +43,7 @@ macro_rules! pow_via_repeated_squaring {
         result
     }};
 }
+#[cfg(any(feature = "ark_ff", feature = "crypto_bigint"))]
 pub(crate) use pow_via_repeated_squaring;
 
 /// Will fail compilation if trait is not implemented for the type.

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -11,9 +11,9 @@
 pub mod crypto_bigint_int;
 
 use crate::{
-    ConstIntSemiring, ConstIntSemiringConfig, ConstSemiring, FixedConfig, IntSemiring,
-    IntSemiringConfig, IntSemiringWithDivRem, IntSemiringWithShifts, Semiring, SemiringConfig,
-    SetElement, helpers::define_blanket_trait,
+    ConstIntSemiring, ConstIntSemiringConfig, ConstSemiring, FixedConfig, IntSemiringConfig,
+    IntSemiringWithDivRem, IntSemiringWithShifts, Semiring, SemiringConfig, SetElement,
+    helpers::define_blanket_trait,
 };
 use core::ops::Neg;
 use num_traits::{CheckedNeg, Signed};

--- a/src/ring/crypto_bigint_int.rs
+++ b/src/ring/crypto_bigint_int.rs
@@ -1,6 +1,6 @@
-use super::*;
 use crate::{
-    Wrapper, boolean::Boolean, crypto_bigint_uint::Uint, helpers::pow_via_repeated_squaring,
+    IntSemiring, Wrapper, boolean::Boolean, crypto_bigint_uint::Uint,
+    helpers::pow_via_repeated_squaring,
 };
 use core::{
     cmp::Ordering,
@@ -904,7 +904,7 @@ pub type I32768 = Int<{ 512 * WORD_FACTOR }>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ensure_type_implements_trait;
+    use crate::{ConstIntRing, IntRingWithShifts, ensure_type_implements_trait};
     use alloc::{format, string::ToString, vec::Vec};
 
     #[cfg(target_pointer_width = "64")]

--- a/src/semiring/ark_ff_bigint.rs
+++ b/src/semiring/ark_ff_bigint.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::{Wrapper, boolean::Boolean, helpers::pow_via_repeated_squaring};
-use alloc::{format, vec::Vec};
+#[cfg(feature = "serde")]
+use alloc::format;
+use alloc::vec::Vec;
 use ark_ff::{BigInt as ArkBigInt, BigInteger as ArkBigInteger};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
@@ -770,7 +772,6 @@ mod tests {
     use super::*;
     use crate::ensure_type_implements_trait;
     use alloc::{format, string::ToString, vec::Vec};
-    use ark_std::rand::Rng;
     use core::cmp::Ordering;
 
     type BigInt1 = BigInt<1>;
@@ -1112,6 +1113,7 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn random_generation() {
+        use ark_std::rand::Rng;
         use rand::prelude::*;
         // Use a seeded RNG for reproducibility
 

--- a/src/semiring/crypto_bigint_boxed_uint.rs
+++ b/src/semiring/crypto_bigint_boxed_uint.rs
@@ -12,9 +12,7 @@ use core::{
     },
     str::FromStr,
 };
-use crypto_bigint::{
-    BitOps, ConcatenatingMul, DivVartime, Integer, Limb, RandomBitsError, Resize, UintRef, Word,
-};
+use crypto_bigint::{BitOps, ConcatenatingMul, DivVartime, Integer, Limb, Resize, UintRef, Word};
 use num_traits::{
     CheckedAdd, CheckedMul, CheckedRem, CheckedSub, One, Pow, WrappingAdd, WrappingMul,
     WrappingSub, Zero,
@@ -716,7 +714,7 @@ impl crypto_bigint::RandomBits for BoxedUint {
     fn try_random_bits<R: TryRng + ?Sized>(
         rng: &mut R,
         bit_length: u32,
-    ) -> Result<Self, RandomBitsError<R::Error>> {
+    ) -> Result<Self, crypto_bigint::RandomBitsError<R::Error>> {
         crypto_bigint::BoxedUint::try_random_bits(rng, bit_length).map(Self)
     }
 
@@ -724,7 +722,7 @@ impl crypto_bigint::RandomBits for BoxedUint {
         rng: &mut R,
         bit_length: u32,
         bits_precision: u32,
-    ) -> Result<Self, RandomBitsError<R::Error>> {
+    ) -> Result<Self, crypto_bigint::RandomBitsError<R::Error>> {
         crypto_bigint::BoxedUint::try_random_bits_with_precision(rng, bit_length, bits_precision)
             .map(Self)
     }


### PR DESCRIPTION
## Context

I started to work on issue #40  but the current build is broken(`cargo build --no-default-features`). the ci might pass because it runs with `all-features` flag. It builds fine with default build as well. 

## Problem
- Cargo builds a dep with union of the feaures every crate requests. For eg., Debug for `syn::Path` requires `extra-traits` feature which is pulled by an arkworks crate. I removed Debug derive anyway from `Op` because its not needed now. Features are not independent and some of them use `dep/feature` form. For eg: `serde` feature pulls `crypto-bigint` unconditionally.

## Fixes
I fixed with conditional `dep?/feature`. Also added a feature matix in CI which builds with every combination to check if any fails. And some other minor dep fixes